### PR TITLE
Close the connection when a parsing exception is thrown

### DIFF
--- a/src/main/java/com/okta/sdk/framework/JsonApiClient.java
+++ b/src/main/java/com/okta/sdk/framework/JsonApiClient.java
@@ -48,14 +48,20 @@ public abstract class JsonApiClient extends ApiClient {
 
     @Override
     protected  <T> T unmarshall(HttpResponse response, TypeReference<T> clazz) throws IOException {
-        if (response.getEntity() == null || clazz.getType().equals(Void.class)) {
+        T toReturn = null;
+
+        try {
+
+            if (response.getEntity() != null && !Void.class.equals(clazz.getType())) {
+                InputStream inputStream = response.getEntity().getContent();
+                JsonParser parser = objectMapper.getFactory().createParser(inputStream);
+                toReturn = parser.readValueAs(clazz);
+            }
+
+        } finally {
             EntityUtils.consume(response.getEntity());
-            return null;
         }
-        InputStream inputStream = response.getEntity().getContent();
-        JsonParser parser = objectMapper.getFactory().createParser(inputStream);
-        T toReturn = parser.readValueAs(clazz);
-        EntityUtils.consume(response.getEntity());
+
         return toReturn;
     }
 


### PR DESCRIPTION
If a parsing exception is thrown while trying to read the HTTP response, the `HttpClient` connection is not closed properly. Once all the connections in the pool have reached this state, the client is unable to send any requests to the Okta API until the service is restarted. This issue was found during a penetration test and rendered our service unresponsive. I re-worked the `JsonApiClient.unmarshall()` method to attempt to close the connection in a finally block to prevent this issue from occurring.
