### PR TITLE
:seedling: Expose Refresh Session endpoint and deprecate Extend Sessi…

### DIFF
--- a/src/main/java/com/okta/sdk/clients/SessionApiClient.java
+++ b/src/main/java/com/okta/sdk/clients/SessionApiClient.java
@@ -80,8 +80,14 @@ public class SessionApiClient extends JsonApiClient {
         });
     }
 
+    @Deprecated
     public Session extendSession(String sessionId) throws IOException  {
         return put(getEncodedPath("/%s", sessionId), new TypeReference<Session>() {
+        });
+    }
+
+    public Session refreshSession(String sessionId) throws IOException  {
+        return post(getEncodedPath("/%s/lifecycle/refresh", sessionId), null, new TypeReference<Session>() {
         });
     }
 


### PR DESCRIPTION
…on endpoint

The Extend Session endpoint was deprecated and replaced with the Refresh Session endpoint
http://developer.okta.com/docs/api/resources/sessions\#refresh-session