### PR TITLE
Idea: Use annotations and helper trait to cleanup test resources

### DIFF
--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/spec/UserIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/spec/UserIT.groovy
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 Okta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.sdk.tests.it.spec
+
+import com.okta.sdk.client.Client
+import com.okta.sdk.resource.user.UserBuilder
+import com.okta.sdk.tests.TestResources
+import com.okta.sdk.tests.Scenario
+import com.okta.sdk.tests.it.util.ClientProvider
+import org.testng.annotations.Test
+
+import static org.hamcrest.Matchers.*
+import static org.hamcrest.MatcherAssert.*
+import static com.okta.sdk.tests.it.util.Util.*
+
+class UserIT implements ClientProvider {
+
+    @Test
+    @Scenario("user-profile-update")
+    @TestResources(users="joe.coder@example.com")
+    void profileUpdateTest() {
+
+        Client client = getClient()
+
+        def password = 'Abcd1234'
+        def firstName = 'Joe'
+        def lastName = 'Coder'
+        def email = 'joe.coder@example.com'
+
+        // 1. Create a user with password & recovery question
+        def user = UserBuilder.instance()
+                .setEmail(email)
+                .setFirstName(firstName)
+                .setLastName(lastName)
+                .setPassword(password)
+                .buildAndCreate(client, false)
+
+        registerForCleanup(user)
+
+        validateUser(user, firstName, lastName, email)
+
+        // 2. Update the user profile
+        def originalLastUpdated = user.lastUpdated
+        sleep(1000)
+        user.getProfile().put("nickName", "Batman")
+        user.update()
+
+        assertThat(user.lastUpdated, greaterThan(originalLastUpdated))
+        assertThat(user.profile.get("nickName"), equalTo("Batman"))
+    }
+}

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/util/ClientProvider.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/util/ClientProvider.groovy
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2017 Okta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.sdk.tests.it.util
+
+import com.okta.sdk.client.Client
+import com.okta.sdk.client.Clients
+import com.okta.sdk.resource.Deletable
+import com.okta.sdk.resource.ResourceException
+import com.okta.sdk.resource.user.User
+import com.okta.sdk.resource.user.UserStatus
+import com.okta.sdk.tests.Scenario
+import com.okta.sdk.tests.TestResources
+import org.testng.Assert
+import org.testng.IHookCallBack
+import org.testng.IHookable
+import org.testng.ITestResult
+import org.testng.annotations.AfterMethod
+import org.testng.annotations.Listeners
+
+
+/**
+ * Creates a thread local client for a test method to use. The client may be connected to an actual Okta instance or a Test Server.
+ */
+@Listeners(ClientProvider)
+trait ClientProvider implements IHookable {
+
+    private ThreadLocal<Client> threadLocal = new ThreadLocal<>()
+    private Collection<Deletable> toBeDeleted = []
+
+    Client getClient() {
+        Client client = threadLocal.get()
+        if (client == null) {
+            client = Clients.builder().build()
+        }
+        return client
+    }
+
+    @Override
+    void run(IHookCallBack callBack, ITestResult testResult) {
+
+        // Gets the current scenario (if one is defined)
+        Scenario scenario = testResult.getMethod().getConstructorOrMethod().getMethod().getAnnotation(Scenario)
+        // Gets test resource if defined
+        TestResources testResources = testResult.getMethod().getConstructorOrMethod().getMethod().getAnnotation(TestResources)
+
+        try {
+            // setup the scenario
+            if (scenario != null) {
+                threadLocal.set(null)
+            }
+
+            Client client = getClient()
+
+            // delete any users that may collide with the test that is about to run
+            testResources.users().each {email ->
+                deleteUser(email, client)
+            }
+
+            // run the tests
+            callBack.runTestMethod(testResult)
+        }
+        finally {
+            // cleanup the thread local
+            threadLocal.remove()
+        }
+    }
+
+    /**
+     * Registers a Deletable to be cleaned up after the test is run.
+     * @param deletable Resource to be deleted.
+     */
+    void registerForCleanup(Deletable deletable) {
+        toBeDeleted.add(deletable)
+    }
+
+    void deleteUser(String email, Client client) {
+        Util.ignoring(ResourceException) {
+            User user = client.getUser(email)
+            if (user.status != UserStatus.DEPROVISIONED) {
+                user.deactivate()
+            }
+            user.delete()
+        }
+    }
+
+    @AfterMethod
+    void clean() {
+        boolean exceptionThrown = false
+        toBeDeleted.each {deletable ->
+            try {
+                if (deletable instanceof User) {
+                    deletable.deactivate()
+                }
+                deletable.delete()
+            }
+            catch (Exception e) {
+                System.err.println("Exception thrown during cleanup, it is ignored so the rest of the cleanup can be run")
+                e.printStackTrace()
+            }
+        }
+        if (exceptionThrown) {
+            Assert.fail("Exception thrown during cleanup, see above exceptions")
+        }
+    }
+
+}

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/util/Util.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/util/Util.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 Okta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.sdk.tests.it.util
+
+import com.okta.sdk.resource.user.User
+import com.okta.sdk.resource.user.UserList
+
+import java.util.stream.Collectors
+import java.util.stream.StreamSupport
+
+import static org.hamcrest.MatcherAssert.*
+import static org.hamcrest.Matchers.*
+import static org.hamcrest.Matchers.hasSize
+import static org.hamcrest.Matchers.notNullValue
+
+class Util {
+
+    static void validateUser(User user, String firstName, String lastName, String email, String login=email) {
+
+        assertThat(user.profile, notNullValue())
+        assertThat(user.profile.firstName, equalTo(firstName))
+        assertThat(user.profile.lastName, equalTo(lastName))
+        assertThat(user.profile.email, equalTo(email))
+        assertThat(user.profile.login, equalTo(login))
+    }
+
+    static void validateUser(User user, User expectedUser) {
+        assertThat(user, equalTo(expectedUser))
+    }
+
+    static void assertUserPresent(UserList results, expectedUser) {
+
+        List<User> usersFound = StreamSupport.stream(results.spliterator(), false)
+                .filter {user -> user.id == expectedUser.id}
+                .collect(Collectors.toList())
+
+        assertThat(usersFound, hasSize(1))
+    }
+
+    static def ignoring = { Class<? extends Throwable> catchMe, Closure callMe ->
+        try {
+            callMe.call()
+        } catch(e) {
+            if (!e.class.isAssignableFrom(catchMe)) {
+                throw e
+            }
+        }
+    }
+}

--- a/integration-tests/src/test/java/com.okta.sdk.tests/Scenario.java
+++ b/integration-tests/src/test/java/com.okta.sdk.tests/Scenario.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 Okta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.sdk.tests;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotates a test with a scenario name.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Scenario {
+    String value();
+}

--- a/integration-tests/src/test/java/com.okta.sdk.tests/TestResources.java
+++ b/integration-tests/src/test/java/com.okta.sdk.tests/TestResources.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 Okta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.sdk.tests;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotates a test with a scenario name.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface TestResources {
+
+    String[] users() default {};
+
+    // TODO: figure out what to do for other resources like groups
+    //String[] groups() default {};
+}

--- a/swagger-templates/src/main/resources/OktaJava/modelInterface.mustache
+++ b/swagger-templates/src/main/resources/OktaJava/modelInterface.mustache
@@ -15,13 +15,15 @@
 }}
 import java.util.Map;
 import com.okta.sdk.resource.Resource;
+import com.okta.sdk.resource.Deletable;
+import com.okta.sdk.resource.Saveable;
 
 {{#models}}{{#model}}
 /**
  * {{#description}}{{.}}{{/description}}{{^description}}{{classname}}{{/description}}
  */
 {{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
-public interface {{classname}} extends Resource{{#vendorExtensions.x-okta-extensible}}, Map<String, Object>{{/vendorExtensions.x-okta-extensible}} {
+public interface {{classname}} extends Resource{{#vendorExtensions.x-okta-extensible}}, Map<String, Object>{{/vendorExtensions.x-okta-extensible}}{{#vendorExtensions.deletable}}, Deletable{{/vendorExtensions.deletable}} {
 
 {{#vars}}
     {{#vendorExtensions.extraAnnotation}}


### PR DESCRIPTION
NOTE: the Client configuration will change in the future, but this keeps all of the IT client creations in one place (they may need to change per test method/scenario)

See: e5fffab6cc8d014d365b4c9411c750cc3ea463c4