### PR TITLE
Stabilize DefaultCacheTest by increasing  the expected TTI and TTL of the test

### DIFF
--- a/impl/src/main/java/com/okta/sdk/impl/cache/DefaultCache.java
+++ b/impl/src/main/java/com/okta/sdk/impl/cache/DefaultCache.java
@@ -19,6 +19,8 @@ import com.okta.sdk.cache.Cache;
 import com.okta.sdk.impl.util.SoftHashMap;
 import com.okta.sdk.lang.Assert;
 import com.okta.sdk.lang.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -33,6 +35,8 @@ import java.util.concurrent.atomic.AtomicLong;
  * @since 0.5.0
  */
 public class DefaultCache<K, V> implements Cache<K, V> {
+
+    private final Logger logger = LoggerFactory.getLogger(DefaultCache.class);
 
     /**
      * Backing map instance that stores the cache entries.
@@ -168,6 +172,7 @@ public class DefaultCache<K, V> implements Cache<K, V> {
             if (sinceCreation.isGreaterThan(ttl)) {
                 map.remove(key);
                 missCount.incrementAndGet(); //count an expired TTL as a miss
+                logger.trace("Removing {} from cache due to TTL, sinceCreation: {}", key, sinceCreation);
                 return null;
             }
         }
@@ -177,6 +182,7 @@ public class DefaultCache<K, V> implements Cache<K, V> {
             if (sinceLastAccess.isGreaterThan(tti)) {
                 map.remove(key);
                 missCount.incrementAndGet(); //count an expired TTI as a miss
+                logger.trace("Removing {} from cache due to TTI, sinceLastAccess: {}", key, sinceLastAccess);
                 return null;
             }
         }

--- a/impl/src/test/groovy/com/okta/sdk/impl/cache/DefaultCacheTest.groovy
+++ b/impl/src/test/groovy/com/okta/sdk/impl/cache/DefaultCacheTest.groovy
@@ -223,7 +223,7 @@ class DefaultCacheTest {
     @Test
     void testTimeToLiveAndTimeToIdle() {
 
-        def cache = new DefaultCache('foo', [:], new Duration(50, TimeUnit.MILLISECONDS), new Duration(20, TimeUnit.MILLISECONDS))
+        def cache = new DefaultCache('foo', [:], new Duration(100, TimeUnit.MILLISECONDS), new Duration(40, TimeUnit.MILLISECONDS))
 
         def key = 'key'
         def value = 'value'
@@ -238,17 +238,17 @@ class DefaultCacheTest {
         //each time we access after sleeping 15 seconds, we should always acquire the value since the last
         //access timestamp is being updated, preventing expunging due to idle.
 
-        Thread.sleep(10)
+        Thread.sleep(20)
         found = cache.get(key)
         assertEquals(found, value)
         assertEquals 1, cache.size()
 
-        Thread.sleep(10)
+        Thread.sleep(20)
         found = cache.get(key)
         assertEquals(found, value)
         assertEquals 1, cache.size()
 
-        Thread.sleep(10)
+        Thread.sleep(20)
         found = cache.get(key)
         assertEquals(found, value)
         assertEquals 1, cache.size()
@@ -256,8 +256,8 @@ class DefaultCacheTest {
         //Now we need to ensure that no matter how frequently the value is used (not idle), we still need to remove
         //the value if older than the TTL
 
-        //10 + 10 + 10 = 30.  Add another 30 millis, and we'll be ~ 60 millis, which is older than the TTL of 50 above.
-        Thread.sleep(30)
+        //20 + 20 + 20 = 60.  Add another 50 millis, and we'll be ~ 110 millis, which is older than the TTL of 100 above.
+        Thread.sleep(50)
 
         found = cache.get(key)
         assertNull found


### PR DESCRIPTION
Added trace logging to DefaultCache to help debug TTL and TTL expiration