### PR TITLE
When looking for the maven 'target' directory use the last one

### DIFF
--- a/swagger-templates/src/main/java/com/okta/swagger/codegen/OktaJavaClientImplCodegen.java
+++ b/swagger-templates/src/main/java/com/okta/swagger/codegen/OktaJavaClientImplCodegen.java
@@ -278,8 +278,9 @@ public class OktaJavaClientImplCodegen extends AbstractOktaJavaClientCodegen
         });
 
         // now dump this to yaml
-        // cheat a little here because we are assuming we are using maven
-        String mavenTargetDir = outputFolder().replaceFirst("/target/.*", "/target");
+        // cheat a little here because we are assuming we are using maven, replace the LAST index of /target/ (the
+        // release process will have two 'target' directories in the path
+        String mavenTargetDir = outputFolder().substring(0, outputFolder.lastIndexOf("/target/") + 8);
         File destFile = new File(
                 new File(mavenTargetDir), "generated-resources/swagger/" + overrideModelPackage.replace('.', '/') +
                 "/discrimination.yaml");


### PR DESCRIPTION
We cannot make any assumptions about the the folders above the 'target' directory, only below
NOTE: the release plugin creates a target/checkout/imp/target directory