### PR TITLE
Expose property util methods to any generated object marked with 'x-okta-extensible' i.e. UserProfile

### DIFF
--- a/api/src/main/java/com/okta/sdk/resource/PropertyRetriever.java
+++ b/api/src/main/java/com/okta/sdk/resource/PropertyRetriever.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 Okta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.sdk.resource;
+
+import java.util.List;
+
+public interface PropertyRetriever {
+
+    String getString(String key);
+
+    Double getNumber(String key);
+
+    Boolean getBoolean(String key);
+
+    Integer getInteger(String key);
+
+    List<String> getStringList(String key);
+
+    List<Double> getNumberList(String key);
+
+    List<Integer> getIntegerList(String key);
+}

--- a/impl/src/main/java/com/okta/sdk/impl/resource/AbstractPropertyRetriever.java
+++ b/impl/src/main/java/com/okta/sdk/impl/resource/AbstractPropertyRetriever.java
@@ -17,6 +17,7 @@ package com.okta.sdk.impl.resource;
 
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import com.okta.sdk.lang.Assert;
+import com.okta.sdk.resource.PropertyRetriever;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +36,7 @@ import java.util.stream.Collectors;
  *
  * @since 0.5.0
  */
-public abstract class AbstractPropertyRetriever {
+public abstract class AbstractPropertyRetriever implements PropertyRetriever {
 
     private static final Logger log = LoggerFactory.getLogger(AbstractPropertyRetriever.class);
 
@@ -55,6 +56,41 @@ public abstract class AbstractPropertyRetriever {
 
     public abstract Object getProperty(String name);
 
+    @Override
+    public String getString(String key) {
+        return getStringProperty(key);
+    }
+
+    @Override
+    public Integer getInteger(String key) {
+        return getIntProperty(key);
+    }
+
+    @Override
+    public Double getNumber(String key) {
+        return getDoubleProperty(key);
+    }
+
+    @Override
+    public Boolean getBoolean(String key) {
+        return getNullableBooleanProperty(key);
+    }
+
+    @Override
+    public List<String> getStringList(String key) {
+        return getListProperty(key);
+    }
+
+    @Override
+    public List<Integer> getIntegerList(String key) {
+        return getListProperty(key);
+    }
+
+    @Override
+    public List<Double> getNumberList(String key) {
+        return getListProperty(key);
+    }
+
     protected String getString(StringProperty property) {
         return getStringProperty(property.getName());
     }
@@ -66,7 +102,6 @@ public abstract class AbstractPropertyRetriever {
         }
         return String.valueOf(value);
     }
-
 
     protected int getInt(IntegerProperty property) {
         Integer value = getIntProperty(property.getName());

--- a/impl/src/main/java/com/okta/sdk/impl/resource/AbstractResource.java
+++ b/impl/src/main/java/com/okta/sdk/impl/resource/AbstractResource.java
@@ -665,37 +665,4 @@ public abstract class AbstractResource extends AbstractPropertyRetriever impleme
         }
         return resultMap;
     }
-
-
-    String getString(String key) {
-        return getStringProperty(key);
-    }
-
-    Integer getInteger(String key) {
-        return getIntProperty(key);
-    }
-
-    Double getDouble(String key) {
-        return getDoubleProperty(key);
-    }
-
-    Double getNumber(String key) {
-        return getDoubleProperty(key);
-    }
-
-    Boolean getBoolean(String key) {
-        return getNullableBooleanProperty(key);
-    }
-
-    List<String> getStringList(String key) {
-        return getListProperty(key);
-    }
-
-    List<Integer> getIntegerList(String key) {
-        return getListProperty(key);
-    }
-
-    List<Double> getNumberList(String key) {
-        return getListProperty(key);
-    }
 }

--- a/swagger-templates/src/main/resources/OktaJava/modelInterface.mustache
+++ b/swagger-templates/src/main/resources/OktaJava/modelInterface.mustache
@@ -17,13 +17,13 @@ import java.util.Map;
 import com.okta.sdk.resource.Resource;
 import com.okta.sdk.resource.Deletable;
 import com.okta.sdk.resource.Saveable;
-
+{{#vendorExtensions.x-okta-extensible}}import com.okta.sdk.resource.PropertyRetriever;{{/vendorExtensions.x-okta-extensible}}
 {{#models}}{{#model}}
 /**
  * {{#description}}{{.}}{{/description}}{{^description}}{{classname}}{{/description}}
  */
 {{>generatedAnnotation}}{{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
-public interface {{classname}} extends Resource{{#parent}}, {{.}}{{/parent}}{{#vendorExtensions.x-okta-extensible}}, Map<String, Object>{{/vendorExtensions.x-okta-extensible}}{{#vendorExtensions.deletable}}, Deletable{{/vendorExtensions.deletable}} {
+public interface {{classname}} extends Resource{{#parent}}, {{.}}{{/parent}}{{#vendorExtensions.x-okta-extensible}}, PropertyRetriever, Map<String, Object>{{/vendorExtensions.x-okta-extensible}}{{#vendorExtensions.deletable}}, Deletable{{/vendorExtensions.deletable}} {
 
 {{#vars}}
     {{#vendorExtensions.extraAnnotation}}


### PR DESCRIPTION
This adds the following methods to mimic what Okta supports with custom profile schemas:

    String getString(String key);
    Double getNumber(String key);
    Boolean getBoolean(String key);
    Integer getInteger(String key);
    List<String> getStringList(String key);
    List<Double> getNumberList(String key);
    List<Integer> getIntegerList(String key);