### PR TITLE
Allow for optional bodies.

### DIFF
--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/UsersIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/UsersIT.groovy
@@ -297,6 +297,30 @@ class UsersIT implements CrudTestSupport {
     }
 
     @Test
+    @TestResources(users = "john-forgot-password@example.com")
+    void forgotPasswordTest() {
+
+        def password = 'Abcd1234'
+        def firstName = 'John'
+        def lastName = 'Forgot-Password'
+        def email = 'john-forgot-password@example.com'
+
+        // 1. Create a user
+        User user = UserBuilder.instance()
+                .setEmail(email)
+                .setFirstName(firstName)
+                .setLastName(lastName)
+                .setPassword(password)
+                .setActive(true)
+                .buildAndCreate(client)
+        registerForCleanup(user)
+        validateUser(user, firstName, lastName, email)
+
+        ForgotPasswordResponse response = user.forgotPassword(false, null)
+        assertThat response.getResetPasswordUrl(), containsString("/reset_password/")
+    }
+
+    @Test
     @Scenario("user-expire-password")
     @TestResources(users = "john-expire-password@example.com")
     void expirePasswordTest() {

--- a/swagger-templates/src/main/resources/OktaJavaImpl/apiMethodPostResource.mustache
+++ b/swagger-templates/src/main/resources/OktaJavaImpl/apiMethodPostResource.mustache
@@ -27,7 +27,12 @@
         {{/vendorExtensions.bodyIsSelf}}
         {{^vendorExtensions.bodyIsSelf}}
             {{#bodyParam}}
+                {{#bodyParam.required}}
             {{bodyParam.paramName}},
+                {{/bodyParam.required}}
+                {{^bodyParam.required}}
+            ({{bodyParam.paramName}} != null) ? {{bodyParam.paramName}} : getDataStore().instantiate(VoidResource.class),
+                {{/bodyParam.required}}
             {{/bodyParam}}
         {{/vendorExtensions.bodyIsSelf}}
         {{^bodyParam}}


### PR DESCRIPTION
`User.forgotPassword()` has an optional arg `UserCredentials`.  If this argument can now be null.
Included IT

Fixes: #146