### PR TITLE
Maven pom cleanup before release

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -54,11 +54,6 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -36,12 +36,10 @@
 
     <properties>
         <swagger-annotations.version>1.5.8</swagger-annotations.version>
-        <jersey.version>2.22.2</jersey.version>
         <jackson.version>2.8.8</jackson.version>
-        <jodatime.version>2.7</jodatime.version>
         <snakeyaml.version>1.17</snakeyaml.version>
         <jjwt.version>0.6.0</jjwt.version>
-        <okta.sdk.pereviousVersion>0.7.0</okta.sdk.pereviousVersion>
+        <okta.sdk.pereviousVersion>0.10.0</okta.sdk.pereviousVersion>
 
         <github.slug>okta/okta-sdk-java</github.slug>
     </properties>
@@ -128,11 +126,6 @@
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
                 <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>joda-time</groupId>
-                <artifactId>joda-time</artifactId>
-                <version>${jodatime.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.yaml</groupId>
@@ -271,6 +264,14 @@
                         </dependency>
                     </dependencies>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>versions-maven-plugin</artifactId>
+                    <version>2.5</version>
+                    <configuration>
+                        <generateBackupPoms>false</generateBackupPoms>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -321,6 +322,14 @@
                                 <breakBuildBasedOnSemanticVersioning>true</breakBuildBasedOnSemanticVersioning>
                             </parameter>
                         </configuration>
+                        <executions>
+                            <execution>
+                                <id>japicmp</id>
+                                <goals>
+                                    <goal>cmp</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
minor cruft cleanup:
- Joda time and Jersey are NOT a dependency any more (it shouldn't have been in the pom)
- configure the maven-versions-plugin to set generateBackupPoms (to save a step on the command line when manually bumping the version)
- Execute japicmp from CI, once we move to 1.0, the CI will start failing with API breaking changes
