### PR TITLE
Use Travis Deploy Step to deploy javadoc instead of script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,13 @@ script:
 - "./src/ci/build.sh"
 after_success:
   - bash <(curl -s https://codecov.io/bash) -f coverage/target/site/jacoco-aggregate/jacoco.xml
+
+deploy:
+  - provider: pages
+    skip_cleanup: true
+    github_token: $GH_API_KEY
+    local_dir: target/gh-pages
+    email: developers@okta.com
+    name: Travis CI - Auto Doc Build
+    on:
+      branch: master

--- a/src/ci/build.sh
+++ b/src/ci/build.sh
@@ -31,9 +31,8 @@ else
         $MVN_CMD deploy -Pci
 
         # also deploy the javadocs to the site
-        git config --global user.email "developers@okta.com"
-        git config --global user.name "okta-sdk-java Auto Doc Build"
-        $MVN_CMD javadoc:aggregate scm-publish:publish-scm -Ppub-docs -Pci
+        git clone -b gh-pages https://github.com/${REPO_SLUG}.git target/gh-pages/
+        $MVN_CMD javadoc:aggregate -Ppub-docs -Pci
     else
         # else try to run the ITs if possible (for someone who has push access to the repo
         if [ "$RUN_ITS" = true ] ; then

--- a/src/ci/finalize-release.sh
+++ b/src/ci/finalize-release.sh
@@ -22,7 +22,7 @@ source "${COMMON_SCRIPT}"
 
 # TODO: we must use our local maven settings file as this script is NOT ready for triggered by travis
 # GPG agent configuration needed to sign artifacts
-MVN_CMD="mvn"
+MVN_CMD="./mvnw"
 
 # the release plugin uses this dir to cut the release
 cd target/checkout


### PR DESCRIPTION
This is how our other java repos work