### PR TITLE
Added support to generate backward compatible method signatures when new optional query args are added

### DIFF
--- a/src/swagger/api.yaml
+++ b/src/swagger/api.yaml
@@ -29,7 +29,7 @@
       "name": "Apache-2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "version": "1.2.0"
+    "version": "1.3.0"
   },
   "externalDocs": {
     "description": "Find more info here",
@@ -1062,6 +1062,13 @@
             "in": "query",
             "name": "after",
             "type": "string"
+          },
+          {
+            "default": "",
+            "in": "query",
+            "name": "expand",
+            "type": "string",
+            "x-okta-added-version": "1.3.0"
           }
         ],
         "produces": [
@@ -1141,6 +1148,7 @@
             "type": "string"
           },
           {
+            "default": false,
             "in": "query",
             "name": "removeUsers",
             "type": "boolean"
@@ -1176,6 +1184,13 @@
             "name": "ruleId",
             "required": true,
             "type": "string"
+          },
+          {
+            "default": "",
+            "in": "query",
+            "name": "expand",
+            "type": "string",
+            "x-okta-added-version": "1.3.0"
           }
         ],
         "produces": [
@@ -1453,6 +1468,13 @@
             "in": "query",
             "name": "limit",
             "type": "integer"
+          },
+          {
+            "default": "all",
+            "in": "query",
+            "name": "managedBy",
+            "type": "string",
+            "x-okta-added-version": "1.3.0"
           }
         ],
         "produces": [
@@ -1876,6 +1898,15 @@
             "in": "query",
             "name": "provider",
             "type": "boolean"
+          },
+          {
+            "default": false,
+            "description": "With activate=true, set nextLogin to \"changePassword\" to have the password be EXPIRED, so user must change it the next time they log in.",
+            "in": "query",
+            "name": "nextLogin",
+            "type": "string",
+            "x-okta-added-version": "0.14.0",
+            "x-openapi-v3-schema-ref": "#/definitions/UserNextLogin"
           }
         ],
         "produces": [
@@ -2269,6 +2300,21 @@
             "in": "query",
             "name": "templateId",
             "type": "string"
+          },
+          {
+            "default": 300,
+            "format": "int32",
+            "in": "query",
+            "name": "tokenLifetimeSeconds",
+            "type": "integer",
+            "x-okta-added-version": "1.3.0"
+          },
+          {
+            "default": false,
+            "in": "query",
+            "name": "activate",
+            "type": "boolean",
+            "x-okta-added-version": "1.3.0"
           }
         ],
         "produces": [
@@ -2526,6 +2572,14 @@
             "in": "query",
             "name": "templateId",
             "type": "string"
+          },
+          {
+            "default": 300,
+            "format": "int32",
+            "in": "query",
+            "name": "tokenLifetimeSeconds",
+            "type": "integer",
+            "x-okta-added-version": "1.3.0"
           },
           {
             "in": "body",
@@ -3459,6 +3513,12 @@
           "readOnly": true,
           "type": "string"
         },
+        "profile": {
+          "additionalProperties": {
+            "type": "object"
+          },
+          "type": "object"
+        },
         "settings": {
           "$ref": "#/definitions/ApplicationSettings"
         },
@@ -3820,6 +3880,9 @@
         "app": {
           "$ref": "#/definitions/ApplicationSettingsApplication"
         },
+        "implicitAssignment": {
+          "type": "boolean"
+        },
         "notifications": {
           "$ref": "#/definitions/ApplicationSettingsNotifications"
         }
@@ -4156,6 +4219,26 @@
         "Session"
       ]
     },
+    "EmailAddress": {
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/EmailStatus",
+          "readOnly": true
+        },
+        "type": {
+          "$ref": "#/definitions/EmailType",
+          "readOnly": true
+        },
+        "value": {
+          "readOnly": true,
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "x-okta-tags": [
+        "User"
+      ]
+    },
     "EmailFactor": {
       "properties": {
         "profile": {
@@ -4176,6 +4259,26 @@
       "x-okta-parent": "#/definitions/FactorProfile",
       "x-okta-tags": [
         "UserFactor"
+      ]
+    },
+    "EmailStatus": {
+      "enum": [
+        "VERIFIED",
+        "UNVERIFIED"
+      ],
+      "type": "string",
+      "x-okta-tags": [
+        "User"
+      ]
+    },
+    "EmailType": {
+      "enum": [
+        "PRIMARY",
+        "SECONDARY"
+      ],
+      "type": "string",
+      "x-okta-tags": [
+        "User"
       ]
     },
     "Factor": {
@@ -4226,6 +4329,9 @@
         "status": {
           "$ref": "#/definitions/FactorStatus",
           "readOnly": true
+        },
+        "tokenLifetimeSeconds": {
+          "type": "integer"
         },
         "userId": {
           "type": "string"
@@ -4504,8 +4610,18 @@
     },
     "GroupRule": {
       "properties": {
+        "_embedded": {
+          "additionalProperties": {
+            "type": "object"
+          },
+          "readOnly": true,
+          "type": "object"
+        },
         "actions": {
           "$ref": "#/definitions/GroupRuleAction"
+        },
+        "allGroupsValid": {
+          "type": "boolean"
         },
         "conditions": {
           "$ref": "#/definitions/GroupRuleConditions"
@@ -4730,6 +4846,13 @@
     },
     "JsonWebKey": {
       "properties": {
+        "_links": {
+          "additionalProperties": {
+            "type": "object"
+          },
+          "readOnly": true,
+          "type": "object"
+        },
         "alg": {
           "readOnly": true,
           "type": "string"
@@ -6549,6 +6672,12 @@
     },
     "UserCredentials": {
       "properties": {
+        "emails": {
+          "items": {
+            "$ref": "#/definitions/EmailAddress"
+          },
+          "type": "array"
+        },
         "password": {
           "$ref": "#/definitions/PasswordCredential"
         },
@@ -6560,6 +6689,15 @@
         }
       },
       "type": "object",
+      "x-okta-tags": [
+        "User"
+      ]
+    },
+    "UserNextLogin": {
+      "enum": [
+        "changePassword"
+      ],
+      "type": "string",
       "x-okta-tags": [
         "User"
       ]
@@ -6620,6 +6758,9 @@
         },
         "passCode": {
           "type": "string"
+        },
+        "tokenLifetimeSeconds": {
+          "type": "integer"
         }
       },
       "type": "object",

--- a/swagger-templates/src/main/java/com/okta/swagger/codegen/AbstractOktaJavaClientCodegen.java
+++ b/swagger-templates/src/main/java/com/okta/swagger/codegen/AbstractOktaJavaClientCodegen.java
@@ -71,6 +71,7 @@ public abstract class AbstractOktaJavaClientCodegen extends AbstractJavaCodegen 
     private final String codeGenName;
 
     public static final String API_FILE_KEY = "apiFile";
+    private static final String NON_OPTIONAL_PRAMS = "nonOptionalParams";
     static final String X_OPENAPI_V3_SCHEMA_REF = "x-openapi-v3-schema-ref";
 
     @SuppressWarnings("hiding")
@@ -501,6 +502,9 @@ public abstract class AbstractOktaJavaClientCodegen extends AbstractJavaCodegen 
 
     @Override
     public String toModelImport(String name) {
+        if (languageSpecificPrimitives.contains(name)) {
+            throw new IllegalStateException("Cannot import primitives: "+ name);
+        }
         if (modelTagMap.containsKey(name)) {
             return modelPackage() +"."+ modelTagMap.get(name) +"."+ name;
         }
@@ -592,6 +596,7 @@ public abstract class AbstractOktaJavaClientCodegen extends AbstractJavaCodegen 
                 .filter(cgOp -> cgOp.allParams != null)
                 .forEach(cgOp -> cgOp.allParams.stream()
                         .filter(cgParam -> cgParam.isEnum)
+                        .filter(cgParam -> needToImport(cgParam.dataType))
                         .forEach(cgParam -> importsToAdd.add(toModelImport(cgParam.dataType))));
 
         // add each one as an import
@@ -716,17 +721,31 @@ public abstract class AbstractOktaJavaClientCodegen extends AbstractJavaCodegen 
             if (!nonOptionalParams.isEmpty()) {
                 CodegenParameter param = nonOptionalParams.get(nonOptionalParams.size()-1);
                 param.hasMore = false;
-                co.vendorExtensions.put("nonOptionalParams", nonOptionalParams);
+                co.vendorExtensions.put(NON_OPTIONAL_PRAMS, nonOptionalParams);
             }
 
-            // remove the noOptionalParams if we have trimmed down the list.
-            if (co.vendorExtensions.get("nonOptionalParams") != null && nonOptionalParams.isEmpty()) {
-                co.vendorExtensions.remove("nonOptionalParams");
+            // remove the nonOptionalParams if we have trimmed down the list.
+            if (co.vendorExtensions.get(NON_OPTIONAL_PRAMS) != null && nonOptionalParams.isEmpty()) {
+                co.vendorExtensions.remove(NON_OPTIONAL_PRAMS);
             }
 
-            // remove th body parameter if it was optional
+            // remove the body parameter if it was optional
             if (co.bodyParam != null && !co.bodyParam.required) {
                 co.vendorExtensions.put("optionalBody", true);
+            }
+
+            if (params.parallelStream().anyMatch(param -> param.vendorExtensions.containsKey("x-okta-added-version"))) {
+                List<CodegenParameter> onlyBackwardsCompatibleParams = params.stream()
+                        .filter(param -> !param.vendorExtensions.containsKey("x-okta-added-version"))
+                        .map(CodegenParameter::copy)
+                        .collect(Collectors.toList());
+
+                if (onlyBackwardsCompatibleParams.stream().anyMatch(param -> param.isQueryParam)) {
+                    CodegenParameter lastItem = onlyBackwardsCompatibleParams.get(onlyBackwardsCompatibleParams.size() - 1);
+                    lastItem.hasMore = false;
+                    co.vendorExtensions.put("hasBackwardsCompatibleParams", true);
+                    co.vendorExtensions.put("onlyBackwardsCompatibleParams", onlyBackwardsCompatibleParams);
+                }
             }
         }
     }

--- a/swagger-templates/src/main/resources/OktaJava/api.mustache
+++ b/swagger-templates/src/main/resources/OktaJava/api.mustache
@@ -51,7 +51,8 @@ public interface {{classname}} extends DataStore {
     */
     DataStore getDataStore();
 
-    {{#operation}}{{^vendorExtensions.moved}}
+{{#operation}}
+{{^vendorExtensions.moved}}
     /**
     * {{summary}}
     * {{notes}}
@@ -84,6 +85,27 @@ public interface {{classname}} extends DataStore {
             date     = "{{generatedDate}}",
             comments = "{{httpMethod}} - {{path}}")
     {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#vendorExtensions.nonOptionalParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/vendorExtensions.nonOptionalParams}});
-{{/vendorExtensions.hasOptional}}{{/vendorExtensions.moved}}{{/operation}}
+    {{/vendorExtensions.hasOptional}}
+
+    {{#vendorExtensions.hasBackwardsCompatibleParams}}
+    /**
+    * {{summary}}
+    * {{notes}}
+    {{#vendorExtensions.onlyBackwardsCompatibleParams}}
+    * @param {{paramName}} {{description}} (required)
+    {{/vendorExtensions.onlyBackwardsCompatibleParams}}
+    {{#returnType}}
+    * @return {{returnType}}
+    {{/returnType}}
+    */
+    @javax.annotation.Generated(
+            value    = "{{generatorClass}}",
+            date     = "{{generatedDate}}",
+            comments = "{{httpMethod}} - {{path}}")
+    {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#vendorExtensions.onlyBackwardsCompatibleParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/vendorExtensions.onlyBackwardsCompatibleParams}});
+    {{/vendorExtensions.hasBackwardsCompatibleParams}}
+
+{{/vendorExtensions.moved}}
+{{/operation}}
 }
 {{/operations}}

--- a/swagger-templates/src/main/resources/OktaJava/modelInterface.mustache
+++ b/swagger-templates/src/main/resources/OktaJava/modelInterface.mustache
@@ -81,33 +81,14 @@ public interface {{classname}} extends Resource{{#parent}}, {{.}}{{/parent}}{{#v
             date     = "{{generatedDate}}",
             comments = "{{httpMethod}} - {{path}}")
     {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{#vendorExtensions.alias}}{{vendorExtensions.alias}}{{/vendorExtensions.alias}}{{^vendorExtensions.alias}}{{operationId}}{{/vendorExtensions.alias}}({{#vendorExtensions.nonOptionalParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/vendorExtensions.nonOptionalParams}});
-
-{{/vendorExtensions.hasOptional}}{{/.}}{{/vendorExtensions.operations}}
-
-{{#operation}}{{^vendorExtensions.moved}}
+{{/vendorExtensions.hasOptional}}
+{{#vendorExtensions.hasBackwardsCompatibleParams}}
     /**
     * {{summary}}
     * {{notes}}
-    {{#allParams}}
-    * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
-    {{/allParams}}
-    {{#returnType}}
-    * @return {{returnType}}
-    {{/returnType}}
-    */
-    @javax.annotation.Generated(
-        value    = "{{generatorClass}}",
-        date     = "{{generatedDate}}",
-        comments = "{{httpMethod}} - {{path}}")
-    {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}});
-
-{{#vendorExtensions.hasOptional}}
-    /**
-    * {{summary}}
-    * {{notes}}
-    {{#vendorExtensions.nonOptionalParams}}
+    {{#vendorExtensions.onlyBackwardsCompatibleParams}}
     * @param {{paramName}} {{description}} (required)
-    {{/vendorExtensions.nonOptionalParams}}
+    {{/vendorExtensions.onlyBackwardsCompatibleParams}}
     {{#returnType}}
     * @return {{returnType}}
     {{/returnType}}
@@ -116,7 +97,9 @@ public interface {{classname}} extends Resource{{#parent}}, {{.}}{{/parent}}{{#v
             value    = "{{generatorClass}}",
             date     = "{{generatedDate}}",
             comments = "{{httpMethod}} - {{path}}")
-    {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#vendorExtensions.nonOptionalParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/vendorExtensions.nonOptionalParams}});
-{{/vendorExtensions.hasOptional}}{{/vendorExtensions.moved}}{{/operation}}
+    {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{vendorExtensions.alias}}({{#vendorExtensions.onlyBackwardsCompatibleParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/vendorExtensions.onlyBackwardsCompatibleParams}});
+{{/vendorExtensions.hasBackwardsCompatibleParams}}
+{{/.}}
+{{/vendorExtensions.operations}}
 }
 {{/model}}{{/models}}

--- a/swagger-templates/src/main/resources/OktaJavaImpl/api.mustache
+++ b/swagger-templates/src/main/resources/OktaJavaImpl/api.mustache
@@ -142,6 +142,39 @@ import static com.okta.sdk.lang.Assert.hasText;
 {{/vendorExtensions.isDelete}}
     }
 {{/vendorExtensions.hasOptional}}
+
+{{#vendorExtensions.hasBackwardsCompatibleParams}}
+    /**
+    * {{summary}}
+    * {{notes}}
+    {{#vendorExtensions.onlyBackwardsCompatibleParams}}
+    * @param {{paramName}} {{description}} (required)
+    {{/vendorExtensions.onlyBackwardsCompatibleParams}}
+    {{#returnType}}
+    * @return {{returnType}}
+    {{/returnType}}
+    */
+    @Override
+    @javax.annotation.Generated(
+            value    = "{{generatorClass}}",
+            date     = "{{generatedDate}}",
+            comments = "{{httpMethod}} - {{path}}")
+    public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#vendorExtensions.onlyBackwardsCompatibleParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/vendorExtensions.onlyBackwardsCompatibleParams}}) {
+{{>queryPartialBackwardsCompat}}
+{{#vendorExtensions.isGet}}
+{{>apiMethodGet}}
+{{/vendorExtensions.isGet}}
+{{#vendorExtensions.isPut}}
+{{>apiMethodPut}}
+{{/vendorExtensions.isPut}}
+{{#vendorExtensions.isPost}}
+{{>apiMethodPostClient}}
+{{/vendorExtensions.isPost}}
+{{#vendorExtensions.isDelete}}
+{{>apiMethodDelete}}
+{{/vendorExtensions.isDelete}}
+    }
+{{/vendorExtensions.hasBackwardsCompatibleParams}}
 {{/vendorExtensions.moved}}
 {{/operation}}
 }

--- a/swagger-templates/src/main/resources/OktaJavaImpl/modelImpl.mustache
+++ b/swagger-templates/src/main/resources/OktaJavaImpl/modelImpl.mustache
@@ -176,83 +176,50 @@ public class Default{{classname}} extends {{#parent}}{{.}}{{/parent}}{{^parent}}
 {{/vendorExtensions.isDelete}}
      }
 {{/vendorExtensions.hasOptional}}
+
+{{#vendorExtensions.hasBackwardsCompatibleParams}}
+    /**
+    * {{summary}}
+    * {{notes}}
+    {{#vendorExtensions.onlyBackwardsCompatibleParams}}
+    * @param {{paramName}} {{description}} (required)
+    {{/vendorExtensions.onlyBackwardsCompatibleParams}}
+    {{#returnType}}
+    * @return {{returnType}}
+    {{/returnType}}
+    */
+    @Override
+    @javax.annotation.Generated(
+            value    = "{{generatorClass}}",
+            date     = "{{generatedDate}}",
+            comments = "{{httpMethod}} - {{path}}")
+    public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{#vendorExtensions.alias}}{{vendorExtensions.alias}}{{/vendorExtensions.alias}}{{^vendorExtensions.alias}}{{operationId}}{{/vendorExtensions.alias}}({{#vendorExtensions.onlyBackwardsCompatibleParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/vendorExtensions.onlyBackwardsCompatibleParams}}) {
+
+    {{#vendorExtensions.fromModelPathParams}}{{#.}}        {{{dataType}}} {{paramName}} = {{vendorExtensions.fromModel.getter}}();{{/.}}{{/vendorExtensions.fromModelPathParams}}
+    {{#vendorExtensions.hasPathParents}}
+        Map<String, String> pathArgs = getParamsFromHref("{{path}}");
+        {{#vendorExtensions.pathParents}}
+        String {{.}} = pathArgs.get("{{.}}");
+        {{/vendorExtensions.pathParents}}
+    {{/vendorExtensions.hasPathParents}}
+{{>queryPartialBackwardsCompat}}
+{{#vendorExtensions.isGet}}
+{{>apiMethodGet}}
+{{/vendorExtensions.isGet}}
+{{#vendorExtensions.isPut}}
+{{>apiMethodPut}}
+{{/vendorExtensions.isPut}}
+{{#vendorExtensions.isPost}}
+{{>apiMethodPostClient}}
+{{/vendorExtensions.isPost}}
+{{#vendorExtensions.isDelete}}
+{{>apiMethodDelete}}
+{{/vendorExtensions.isDelete}}
+    }
+{{/vendorExtensions.hasBackwardsCompatibleParams}}
+
 {{/.}}
 {{/vendorExtensions.operations}}
-{{#operation}}
-{{^vendorExtensions.moved}}
-
-    /**
-    * {{summary}}
-    * {{notes}}
-    {{#allParams}}
-    * @param {{paramName}} {{description}}{{#required}} (required){{/required}}{{^required}} (optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
-    {{/allParams}}
-    {{#returnType}}
-    * @return {{returnType}}
-    {{/returnType}}
-    */
-    @Override
-    @javax.annotation.Generated(
-            value    = "{{generatorClass}}",
-            date     = "{{generatedDate}}",
-            comments = "{{httpMethod}} - {{path}}")
-    public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#allParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
-
-{{>queryPartial}}
-{{#vendorExtensions.isGet}}
-{{>apiMethodGet}}
-{{/vendorExtensions.isGet}}
-{{#vendorExtensions.isPut}}
-{{>apiMethodPut}}
-{{/vendorExtensions.isPut}}
-{{#vendorExtensions.isPost}}
-{{>apiMethodPostResource}}
-{{/vendorExtensions.isPost}}
-{{#vendorExtensions.isDelete}}
-{{>apiMethodDelete}}
-{{/vendorExtensions.isDelete}}
-    }
-{{#vendorExtensions.hasOptional}}
-
-    /**
-    * {{summary}}
-    * {{notes}}
-    {{#vendorExtensions.nonOptionalParams}}
-    * @param {{paramName}} {{description}} (required)
-    {{/vendorExtensions.nonOptionalParams}}
-    {{#returnType}}
-    * @return {{returnType}}
-    {{/returnType}}
-    */
-    @Override
-    @javax.annotation.Generated(
-            value    = "{{generatorClass}}",
-            date     = "{{generatedDate}}",
-            comments = "{{httpMethod}} - {{path}}")
-    public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}void {{/returnType}}{{operationId}}({{#vendorExtensions.nonOptionalParams}}{{{dataType}}} {{paramName}}{{#hasMore}}, {{/hasMore}}{{/vendorExtensions.nonOptionalParams}}) {
-
-{{>queryPartialRequired}}
-{{#vendorExtensions.isGet}}
-{{>apiMethodGet}}
-{{/vendorExtensions.isGet}}
-{{#vendorExtensions.isPut}}
-{{>apiMethodPut}}
-{{/vendorExtensions.isPut}}
-{{#vendorExtensions.isPost}}
-    {{#vendorExtensions.optionalBody}}
-{{>apiMethodPostNoBody}}
-    {{/vendorExtensions.optionalBody}}
-    {{^vendorExtensions.optionalBody}}
-{{>apiMethodPostResource}}
-    {{/vendorExtensions.optionalBody}}
-{{/vendorExtensions.isPost}}
-{{#vendorExtensions.isDelete}}
-{{>apiMethodDelete}}
-{{/vendorExtensions.isDelete}}
-    }
-{{/vendorExtensions.hasOptional}}
-{{/vendorExtensions.moved}}
-{{/operation}}
 
 {{/model}}
 {{/models}}

--- a/swagger-templates/src/main/resources/OktaJavaImpl/queryPartialBackwardsCompat.mustache
+++ b/swagger-templates/src/main/resources/OktaJavaImpl/queryPartialBackwardsCompat.mustache
@@ -1,0 +1,19 @@
+{{!
+    Copyright 2017 Okta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+}}
+{{>queryParamValidatePartial}}        QueryString queryArgs = new QueryString();{{#vendorExtensions.onlyBackwardsCompatibleParams}}
+        if ({{paramName}} != null) queryArgs.put("{{baseName}}", {{paramName}});{{/vendorExtensions.onlyBackwardsCompatibleParams}}
+
+        String href = QueryString.buildHref("{{{vendorExtensions.hrefFiltered}}}", queryArgs);

--- a/swagger-templates/src/main/resources/OktaJavaImpl/queryPartialBackwardsCompat.mustache
+++ b/swagger-templates/src/main/resources/OktaJavaImpl/queryPartialBackwardsCompat.mustache
@@ -1,5 +1,5 @@
 {{!
-    Copyright 2017 Okta
+    Copyright 2017-Present Okta, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION

NOTE: initial support only allows for 2 versions (old and new), this may need to change
going forward i.e. if a method signature is updated twice.