### PR TITLE
Generate xref source to make it easer to view the generated source

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta</groupId>
         <artifactId>okta-parent</artifactId>
-        <version>4</version>
+        <version>5</version>
         <relativePath>../okta-java-parent</relativePath>
     </parent>
 
@@ -339,6 +339,14 @@
                             <legacyVersions>
                                 <legacyVersion>0.0.4</legacyVersion>
                             </legacyVersions>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jxr-plugin</artifactId>
+                        <configuration>
+                            <sourcePath>${project.build.sourceDirectory};${root.dir}/api/target/generated-sources/swagger-codegen;${root.dir}/impl/target/generated-sources/swagger-codegen</sourcePath>
+                            <excludes>**/com/okta/swagger/**</excludes>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/src/ci/build.sh
+++ b/src/ci/build.sh
@@ -34,7 +34,7 @@ deploy () {
 
     # also deploy the javadocs to the site
     git clone -b gh-pages https://github.com/${REPO_SLUG}.git target/gh-pages/
-    $MVN_CMD javadoc:aggregate com.okta:okta-doclist-maven-plugin:generate -Ppub-docs -Pci
+    $MVN_CMD javadoc:aggregate com.okta:okta-doclist-maven-plugin:generate jxr:aggregate -Ppub-docs -Pci
 }
 
 full_build () {

--- a/src/ci/finalize-release.sh
+++ b/src/ci/finalize-release.sh
@@ -36,9 +36,9 @@ $MVN_CMD org.sonatype.plugins:nexus-staging-maven-plugin:release
 git clone -b gh-pages git@github.com:${REPO_SLUG}.git target/gh-pages
 
 # publish once to the versioned dir
-$MVN_CMD javadoc:aggregate -Ppub-docs -Djavadoc.version.dir=''
+$MVN_CMD javadoc:aggregate jxr:aggregate -Ppub-docs -Djavadoc.version.dir=''
 # and again to the unversioned dir
-$MVN_CMD javadoc:aggregate com.okta:okta-doclist-maven-plugin:generate -Ppub-docs -Djavadoc.version.dir="${NEW_VERSION}/"
+$MVN_CMD javadoc:aggregate com.okta:okta-doclist-maven-plugin:generate jxr:aggregate -Ppub-docs -Djavadoc.version.dir="${NEW_VERSION}/"
 
 cd target/gh-pages
 git add .


### PR DESCRIPTION
NOTE: CI will fail until the parent pom is released