### PR TITLE
Parse X-Rate-Limit-Reset header to calculate 429 retry delay

### DIFF
--- a/api/src/main/java/com/okta/sdk/client/ClientBuilder.java
+++ b/api/src/main/java/com/okta/sdk/client/ClientBuilder.java
@@ -208,6 +208,7 @@ public interface ClientBuilder {
     String DEFAULT_CLIENT_PROXY_HOST_PROPERTY_NAME = "okta.client.proxy.host";
     String DEFAULT_CLIENT_PROXY_USERNAME_PROPERTY_NAME = "okta.client.proxy.username";
     String DEFAULT_CLIENT_PROXY_PASSWORD_PROPERTY_NAME = "okta.client.proxy.password";
+    String DEFAULT_CLIENT_RETRY_MAX_ELAPSED_PROPERTY_NAME = "okta.client.retry.maxElapsed";
 
     /**
      * Allows specifying an {@code ApiKey} instance directly instead of relying on the
@@ -328,6 +329,14 @@ public interface ClientBuilder {
      * @return the ClientBuilder instance for method chaining
      */
     ClientBuilder setOrgUrl(String baseUrl);
+
+    /**
+     * Sets the maximum number of milliseconds to wait when retrying before giving up.
+     *
+     * @param maxElapsed retry max elapsed duration in milliseconds
+     * @return the ClientBuilder instance for method chaining
+     */
+    ClientBuilder setRetryMaxElapsed(int maxElapsed);
 
     /**
      * Constructs a new {@link Client} instance based on the ClientBuilder's current configuration state.

--- a/api/src/main/java/com/okta/sdk/client/ClientBuilder.java
+++ b/api/src/main/java/com/okta/sdk/client/ClientBuilder.java
@@ -209,6 +209,7 @@ public interface ClientBuilder {
     String DEFAULT_CLIENT_PROXY_USERNAME_PROPERTY_NAME = "okta.client.proxy.username";
     String DEFAULT_CLIENT_PROXY_PASSWORD_PROPERTY_NAME = "okta.client.proxy.password";
     String DEFAULT_CLIENT_RETRY_MAX_ELAPSED_PROPERTY_NAME = "okta.client.retry.maxElapsed";
+    String DEFAULT_CLIENT_RETRY_RATE_LIMIT_MAX_OFFSET = "okta.client.retry.rateLimitMaxOffset";
 
     /**
      * Allows specifying an {@code ApiKey} instance directly instead of relying on the

--- a/api/src/main/java/com/okta/sdk/client/ClientBuilder.java
+++ b/api/src/main/java/com/okta/sdk/client/ClientBuilder.java
@@ -208,8 +208,8 @@ public interface ClientBuilder {
     String DEFAULT_CLIENT_PROXY_HOST_PROPERTY_NAME = "okta.client.proxy.host";
     String DEFAULT_CLIENT_PROXY_USERNAME_PROPERTY_NAME = "okta.client.proxy.username";
     String DEFAULT_CLIENT_PROXY_PASSWORD_PROPERTY_NAME = "okta.client.proxy.password";
-    String DEFAULT_CLIENT_RETRY_MAX_ELAPSED_PROPERTY_NAME = "okta.client.retry.maxElapsed";
-    String DEFAULT_CLIENT_RETRY_RATE_LIMIT_MAX_OFFSET = "okta.client.retry.rateLimitMaxOffset";
+    String DEFAULT_CLIENT_RETRY_MAX_ELAPSED_PROPERTY_NAME = "okta.client.requestTimeout";
+    String DEFAULT_CLIENT_RETRY_MAX_ATTEMPTS_PROPERTY_NAME = "okta.client.rateLimit.maxRetries";
 
     /**
      * Allows specifying an {@code ApiKey} instance directly instead of relying on the
@@ -338,6 +338,14 @@ public interface ClientBuilder {
      * @return the ClientBuilder instance for method chaining
      */
     ClientBuilder setRetryMaxElapsed(int maxElapsed);
+
+    /**
+     * Sets the maximum number of attempts to retrying before giving up.
+     *
+     * @param maxAttempts retry max attempts
+     * @return the ClientBuilder instance for method chaining
+     */
+    ClientBuilder setRetryMaxAttempts(int maxAttempts);
 
     /**
      * Constructs a new {@link Client} instance based on the ClientBuilder's current configuration state.

--- a/api/src/main/java/com/okta/sdk/client/ClientBuilder.java
+++ b/api/src/main/java/com/okta/sdk/client/ClientBuilder.java
@@ -208,7 +208,7 @@ public interface ClientBuilder {
     String DEFAULT_CLIENT_PROXY_HOST_PROPERTY_NAME = "okta.client.proxy.host";
     String DEFAULT_CLIENT_PROXY_USERNAME_PROPERTY_NAME = "okta.client.proxy.username";
     String DEFAULT_CLIENT_PROXY_PASSWORD_PROPERTY_NAME = "okta.client.proxy.password";
-    String DEFAULT_CLIENT_RETRY_MAX_ELAPSED_PROPERTY_NAME = "okta.client.requestTimeout";
+    String DEFAULT_CLIENT_REQUEST_TIMEOUT_PROPERTY_NAME = "okta.client.requestTimeout";
     String DEFAULT_CLIENT_RETRY_MAX_ATTEMPTS_PROPERTY_NAME = "okta.client.rateLimit.maxRetries";
 
     /**

--- a/api/src/main/java/com/okta/sdk/lang/Classes.java
+++ b/api/src/main/java/com/okta/sdk/lang/Classes.java
@@ -21,6 +21,10 @@ import org.slf4j.LoggerFactory;
 
 import java.io.InputStream;
 import java.lang.reflect.Constructor;
+import java.util.Optional;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
+import java.util.stream.StreamSupport;
 
 /**
  * @since 0.5.0
@@ -187,6 +191,20 @@ public class Classes {
         } catch (Exception e) {
             String msg = "Unable to instantiate instance with constructor [" + ctor + "]";
             throw new InstantiationException(msg, e);
+        }
+    }
+
+    public static <T> T loadFromService(Class<T> clazz) {
+        return loadFromService(clazz, "ServiceLoader failed to find implementation for class: " + clazz);
+    }
+
+    public static <T> T loadFromService(Class<T> clazz, String errorMessage) {
+        try {
+            ServiceLoader<T> serviceLoader = ServiceLoader.load(clazz);
+            Optional<T> result = StreamSupport.stream(serviceLoader.spliterator(), false).findFirst();
+            return result.orElseThrow(() -> new IllegalStateException(errorMessage));
+        } catch(ServiceConfigurationError e) {
+            throw new IllegalStateException(errorMessage, e);
         }
     }
 

--- a/httpclient/src/main/java/com/okta/sdk/impl/http/httpclient/HttpClientRequestExecutor.java
+++ b/httpclient/src/main/java/com/okta/sdk/impl/http/httpclient/HttpClientRequestExecutor.java
@@ -306,7 +306,12 @@ public class HttpClientRequestExecutor implements RequestExecutor {
                         // if we cannot pause, then return the original response
                         pauseBeforeRetry(retryCount, httpResponse, timer.split());
                     } catch (RestException e) {
-                        log.warn("Unable to pause for retry: ", e.getMessage(), e);
+                        if (log.isDebugEnabled()) {
+                            log.warn("Unable to pause for retry: {}", e.getMessage(), e);
+                        } else {
+                            log.warn("Unable to pause for retry: {}", e.getMessage());
+                        }
+
                         return toSdkResponse(httpResponse);
                     }
 
@@ -429,7 +434,7 @@ public class HttpClientRequestExecutor implements RequestExecutor {
         } else if (httpResponse != null && httpResponse.getStatusLine().getStatusCode() == 429) {
             delay = get429DelayMillis(httpResponse);
             if (!shouldRetry(retries, timeElapsed + delay)) {
-                throw new RestException("HTTP 429: Too Many Requests.  Exceeded request rate limit in the allotted amount of time.");
+                throw new RestException("Cannot retry request, next request will exceed retry configuration.");
             }
             log.debug("429 detected, will retry in {}ms, attempt number: {}", delay, retries);
         }

--- a/httpclient/src/main/java/com/okta/sdk/impl/http/httpclient/HttpClientRequestExecutor.java
+++ b/httpclient/src/main/java/com/okta/sdk/impl/http/httpclient/HttpClientRequestExecutor.java
@@ -69,7 +69,6 @@ import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.util.Date;
-import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * {@code RequestExecutor} implementation that uses the

--- a/httpclient/src/main/java/com/okta/sdk/impl/http/httpclient/HttpClientRequestExecutor.java
+++ b/httpclient/src/main/java/com/okta/sdk/impl/http/httpclient/HttpClientRequestExecutor.java
@@ -150,7 +150,7 @@ public class HttpClientRequestExecutor implements RequestExecutor {
              clientConfiguration.getConnectionTimeout());
 
         if (clientConfiguration.getRetryMaxElapsed() >= 0) {
-            maxElapsedMillis = clientConfiguration.getRetryMaxElapsed();
+            maxElapsedMillis = clientConfiguration.getRetryMaxElapsed() * 1000;
         }
     }
 

--- a/httpclient/src/main/java/com/okta/sdk/impl/http/httpclient/HttpClientRequestExecutorFactory.java
+++ b/httpclient/src/main/java/com/okta/sdk/impl/http/httpclient/HttpClientRequestExecutorFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.sdk.impl.http.httpclient;
+
+import com.okta.sdk.impl.config.ClientConfiguration;
+import com.okta.sdk.impl.http.RequestExecutor;
+import com.okta.sdk.impl.http.RequestExecutorFactory;
+
+/**
+ * @since 1.2.0
+ */
+public class HttpClientRequestExecutorFactory implements RequestExecutorFactory {
+
+    @Override
+    public RequestExecutor create(ClientConfiguration clientConfiguration) {
+        return new HttpClientRequestExecutor(clientConfiguration);
+    }
+}

--- a/httpclient/src/main/java/com/okta/sdk/impl/http/httpclient/Timer.java
+++ b/httpclient/src/main/java/com/okta/sdk/impl/http/httpclient/Timer.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.sdk.impl.http.httpclient;
+
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+
+class Timer {
+
+    private ZonedDateTime startTime = ZonedDateTime.now();
+
+    long split() {
+        return startTime.until(ZonedDateTime.now(), ChronoUnit.MILLIS);
+    }
+}

--- a/httpclient/src/main/resources/META-INF/services/com.okta.sdk.impl.http.RequestExecutorFactory
+++ b/httpclient/src/main/resources/META-INF/services/com.okta.sdk.impl.http.RequestExecutorFactory
@@ -1,0 +1,1 @@
+com.okta.sdk.impl.http.httpclient.HttpClientRequestExecutorFactory

--- a/httpclient/src/test/groovy/com/okta/sdk/impl/http/httpclient/HttpClientRequestExecutorTest.groovy
+++ b/httpclient/src/test/groovy/com/okta/sdk/impl/http/httpclient/HttpClientRequestExecutorTest.groovy
@@ -92,10 +92,12 @@ class HttpClientRequestExecutorTest {
         clientConfig.setRequestAuthenticatorFactory(new DefaultRequestAuthenticatorFactory())
         clientConfig.setConnectionTimeout(1111)
         clientConfig.setRetryMaxElapsed(2)
+        clientConfig.setRateLimitMaxOffset(3)
 
         def requestExecutor = new HttpClientRequestExecutor(clientConfig)
 
         assertThat requestExecutor.maxElapsedMillis, is(2000)
+        assertThat requestExecutor.rateLimitMaxOffset, is(3000)
     }
 
     @Test
@@ -184,9 +186,9 @@ class HttpClientRequestExecutorTest {
 
         // max randomness plus 500ms for slow CPUs
         assertThat totalTime as Integer, is(both(
-                                                greaterThan(5000))
+                                                greaterThan(6000))
                                             .and(
-                                                lessThan(10500)))
+                                                lessThan(15500)))
     }
 
     @Test
@@ -252,7 +254,7 @@ class HttpClientRequestExecutorTest {
         when(httpResponse.getFirstHeader("Date")).thenReturn(new BasicHeader("Date", dateHeaderValue))
         headers = [new BasicHeader("X-Rate-Limit-Reset", resetTime1.toString())]
         when(httpResponse.getHeaders(limitHeaderName)).thenReturn(headers)
-        assertThat requestExecutor.get429DelayMillis(httpResponse), both(greaterThan(11000L)).and(lessThan(15000L)) // 10 seconds plus 1-5 seconds
+        assertThat requestExecutor.get429DelayMillis(httpResponse), both(greaterThan(11000L)).and(lessThan(20000L)) // 10 seconds plus 1-10 seconds
     }
 
     private static long time(Closure closure) {
@@ -273,7 +275,7 @@ class HttpClientRequestExecutorTest {
         }
     }
 
-    private HttpClientRequestExecutor createRequestExecutor(RequestAuthenticator requestAuthenticator = mock(RequestAuthenticator), int maxElapsed = 10) {
+    private HttpClientRequestExecutor createRequestExecutor(RequestAuthenticator requestAuthenticator = mock(RequestAuthenticator), int maxElapsed = 15) {
 
         def clientCredentials = mock(ClientCredentials)
         def clientConfig = mock(ClientConfiguration)

--- a/httpclient/src/test/groovy/com/okta/sdk/impl/http/httpclient/HttpClientRequestExecutorTest.groovy
+++ b/httpclient/src/test/groovy/com/okta/sdk/impl/http/httpclient/HttpClientRequestExecutorTest.groovy
@@ -26,7 +26,6 @@ import com.okta.sdk.impl.http.HttpHeaders
 import com.okta.sdk.impl.http.QueryString
 import com.okta.sdk.impl.http.Request
 import com.okta.sdk.impl.http.Response
-import com.okta.sdk.impl.http.RestException
 import com.okta.sdk.impl.http.authc.DefaultRequestAuthenticatorFactory
 import com.okta.sdk.impl.http.authc.RequestAuthenticator
 import com.okta.sdk.impl.http.authc.RequestAuthenticatorFactory

--- a/httpclient/src/test/groovy/com/okta/sdk/impl/http/httpclient/HttpClientRequestExecutorTest.groovy
+++ b/httpclient/src/test/groovy/com/okta/sdk/impl/http/httpclient/HttpClientRequestExecutorTest.groovy
@@ -18,10 +18,27 @@ package com.okta.sdk.impl.http.httpclient
 
 import com.okta.sdk.authc.credentials.ClientCredentials
 import com.okta.sdk.client.AuthenticationScheme
+import com.okta.sdk.client.Proxy
+import com.okta.sdk.http.HttpMethod
+import com.okta.sdk.impl.api.DefaultClientCredentialsResolver
+import com.okta.sdk.impl.config.ClientConfiguration
+import com.okta.sdk.impl.http.HttpHeaders
+import com.okta.sdk.impl.http.QueryString
+import com.okta.sdk.impl.http.Request
+import com.okta.sdk.impl.http.Response
+import com.okta.sdk.impl.http.authc.DefaultRequestAuthenticatorFactory
+import com.okta.sdk.impl.http.authc.RequestAuthenticator
+import com.okta.sdk.impl.http.authc.RequestAuthenticatorFactory
+import org.apache.http.Header
 import org.apache.http.HttpEntity
 import org.apache.http.HttpResponse
 import org.apache.http.StatusLine
+import org.apache.http.client.HttpClient
+import org.apache.http.client.methods.HttpRequestBase
+import org.apache.http.message.BasicHeader
 import org.testng.annotations.Test
+
+import java.text.SimpleDateFormat
 
 import static org.mockito.Mockito.*
 import static org.hamcrest.MatcherAssert.*
@@ -60,6 +77,177 @@ class HttpClientRequestExecutorTest {
 
         assertNull sdkResponse.body
         assertThat sdkResponse.httpStatus, is(200)
+    }
 
+    @Test
+    void testClientConfigurationConstructor() {
+
+        def clientCredentials = mock(ClientCredentials)
+
+        def clientConfig = new ClientConfiguration()
+        clientConfig.setClientCredentialsResolver(new DefaultClientCredentialsResolver(clientCredentials))
+        clientConfig.setProxy(new Proxy("example.com", 3333, "proxy-username", "proxy-password"))
+        clientConfig.setAuthenticationScheme(AuthenticationScheme.NONE)
+        clientConfig.setRequestAuthenticatorFactory(new DefaultRequestAuthenticatorFactory())
+        clientConfig.setConnectionTimeout(1111)
+        clientConfig.setRetryMaxElapsed(2222)
+
+        def requestExecutor = new HttpClientRequestExecutor(clientConfig)
+
+        assertThat requestExecutor.maxElapsedMillis, is(2222)
+    }
+
+    @Test
+    void testExecuteRequest() {
+
+        def content = "my-content"
+        def request = mockRequest()
+        def requestAuthenticator = mock(RequestAuthenticator)
+        def httpRequest = mock(HttpRequestBase)
+        def httpClientRequestFactory = mock(HttpClientRequestFactory)
+        def httpClient = mock(HttpClient)
+        def httpResponse = mockHttpResponse(content)
+
+        when(httpClientRequestFactory.createHttpClientRequest(request, null)).thenReturn(httpRequest)
+        when(httpClient.execute(httpRequest)).thenReturn(httpResponse)
+
+        def requestExecutor = createRequestExecutor(requestAuthenticator)
+        requestExecutor.httpClientRequestFactory = httpClientRequestFactory
+        requestExecutor.httpClient = httpClient
+
+        def response = requestExecutor.executeRequest(request)
+        def responseBody = response.body.text
+
+        assertThat responseBody, is(content)
+        assertThat response.httpStatus, is(200)
+        assertThat response.isClientError(), is(false)
+        assertThat response.isError(), is(false)
+        assertThat response.isServerError(), is(false)
+
+        verify(requestAuthenticator).authenticate(request)
+    }
+
+    @Test
+    void testExecuteRequestWith429() {
+
+        def content1 = "fake-429-content"
+        def content2 = "some-content"
+        def request = mockRequest()
+        def httpRequest1 = mock(HttpRequestBase)
+        def httpRequest2 = mock(HttpRequestBase)
+        def dateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz")
+        long currentTime = System.currentTimeMillis()
+        long resetTime = ((currentTime / 1000L) + 5L) as Long // current time plus 5 seconds
+        def dateHeaderValue1 = dateFormat.format(new Date(currentTime))
+        def dateHeaderValue2 = dateFormat.format(new Date(currentTime + 10 * 1000))
+
+        Header[] headers1 = [
+                new BasicHeader("X-Rate-Limit-Reset", resetTime.toString()),
+                new BasicHeader("Date", dateHeaderValue1),
+                new BasicHeader("X-Okta-Request-Id", "a-request-id")]
+
+        Header[] headers2 = [
+                new BasicHeader("Date", dateHeaderValue2),
+                new BasicHeader("X-Okta-Request-Id", "another-request-id")]
+
+        def httpResponse1 = mockHttpResponse(content1, 429, headers1)
+        def httpResponse2 = mockHttpResponse(content2, 200, headers2)
+        def requestAuthenticator = mock(RequestAuthenticator)
+        def httpClientRequestFactory = mock(HttpClientRequestFactory)
+        def httpClient = mock(HttpClient)
+
+        when(httpClient.execute(httpRequest1)).thenReturn(httpResponse1)
+        when(httpClient.execute(httpRequest2)).thenReturn(httpResponse2)
+        when(httpClientRequestFactory.createHttpClientRequest(request, null)).thenReturn(httpRequest1)
+                                                                                          .thenReturn(httpRequest2)
+
+        def requestExecutor = createRequestExecutor(requestAuthenticator)
+        requestExecutor.httpClientRequestFactory = httpClientRequestFactory
+        requestExecutor.httpClient = httpClient
+
+        Response response = null
+        def totalTime = time { response = requestExecutor.executeRequest(request) }
+
+        def responseBody = response.body.text
+
+        assertThat responseBody, is(content2)
+        assertThat response.httpStatus, is(200)
+        assertThat response.isClientError(), is(false)
+        assertThat response.isError(), is(false)
+        assertThat response.isServerError(), is(false)
+
+        def headers = request.getHeaders()
+        verify(headers).add("X-Okta-Retry-For", "a-request-id")
+        verify(headers).add("X-Okta-Retry-Count", "2")
+        verify(requestAuthenticator, times(2)).authenticate(request)
+
+        // max randomness plus 500ms for slow CPUs
+        assertThat totalTime as Integer, is(both(
+                                                greaterThan(5000))
+                                            .and(
+                                                lessThan(6500)))
+    }
+
+    private static long time(Closure closure) {
+        def startTime = System.currentTimeMillis()
+        closure.call()
+        return (System.currentTimeMillis() - startTime)
+    }
+
+    private HttpClientRequestExecutor createRequestExecutor(RequestAuthenticator requestAuthenticator) {
+
+        def clientCredentials = mock(ClientCredentials)
+        def clientConfig = mock(ClientConfiguration)
+        def requestAuthFactory = mock(RequestAuthenticatorFactory)
+
+        when(clientConfig.getClientCredentialsResolver()).thenReturn(new DefaultClientCredentialsResolver(clientCredentials))
+        when(clientConfig.getRequestAuthenticatorFactory()).thenReturn(requestAuthFactory)
+        when(clientConfig.getAuthenticationScheme()).thenReturn(AuthenticationScheme.SSWS)
+        when(clientConfig.getConnectionTimeout()).thenReturn(1111)
+        when(clientConfig.getRetryMaxElapsed()).thenReturn(10 * 1000)
+
+        when(requestAuthFactory.create(AuthenticationScheme.SSWS, clientCredentials)).thenReturn(requestAuthenticator)
+
+        return new HttpClientRequestExecutor(clientConfig)
+    }
+
+    private Request mockRequest(String uri = "https://example.com/a-resource",
+                                HttpMethod method = HttpMethod.GET,
+                                HttpHeaders headers = mock(HttpHeaders),
+                                QueryString queryString = new QueryString()) {
+
+        def request = mock(Request)
+
+        when(request.getQueryString()).thenReturn(queryString)
+        when(request.getHeaders()).thenReturn(headers)
+        when(request.getResourceUrl()).thenReturn(new URI(uri))
+        when(request.getMethod()).thenReturn(method)
+
+        return request
+    }
+
+    private mockHttpResponse(String content, int statusCode = 200, Header[] headers = null) {
+
+        def httpResponse = mock(HttpResponse)
+        def statusLine = mock(StatusLine)
+        def entity = mock(HttpEntity)
+        def entityContent = new ByteArrayInputStream(content.getBytes())
+
+        when(httpResponse.getStatusLine()).thenReturn(statusLine)
+        when(httpResponse.getEntity()).thenReturn(entity)
+        when(httpResponse.getAllHeaders()).thenReturn(headers)
+        if (headers != null) {
+            headers.each {
+                when(httpResponse.getFirstHeader(it.name)).thenReturn(it)
+            }
+        }
+
+        when(statusLine.getStatusCode()).thenReturn(statusCode)
+
+        when(entity.getContentEncoding()).thenReturn(null)
+        when(entity.getContent()).thenReturn(entityContent)
+        when(entity.getContentLength()).thenReturn(content.length().longValue())
+
+        return httpResponse
     }
 }

--- a/httpclient/src/test/groovy/com/okta/sdk/impl/http/httpclient/HttpClientRequestExecutorTest.groovy
+++ b/httpclient/src/test/groovy/com/okta/sdk/impl/http/httpclient/HttpClientRequestExecutorTest.groovy
@@ -91,11 +91,11 @@ class HttpClientRequestExecutorTest {
         clientConfig.setAuthenticationScheme(AuthenticationScheme.NONE)
         clientConfig.setRequestAuthenticatorFactory(new DefaultRequestAuthenticatorFactory())
         clientConfig.setConnectionTimeout(1111)
-        clientConfig.setRetryMaxElapsed(2222)
+        clientConfig.setRetryMaxElapsed(2)
 
         def requestExecutor = new HttpClientRequestExecutor(clientConfig)
 
-        assertThat requestExecutor.maxElapsedMillis, is(2222)
+        assertThat requestExecutor.maxElapsedMillis, is(2000)
     }
 
     @Test
@@ -273,7 +273,7 @@ class HttpClientRequestExecutorTest {
         }
     }
 
-    private HttpClientRequestExecutor createRequestExecutor(RequestAuthenticator requestAuthenticator = mock(RequestAuthenticator), int maxElapsed = 10 * 1000) {
+    private HttpClientRequestExecutor createRequestExecutor(RequestAuthenticator requestAuthenticator = mock(RequestAuthenticator), int maxElapsed = 10) {
 
         def clientCredentials = mock(ClientCredentials)
         def clientConfig = mock(ClientConfiguration)

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -56,6 +56,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+        <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-testng</artifactId>
+            <version>1.7.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>1.7.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/impl/src/main/java/com/okta/sdk/impl/client/AbstractClient.java
+++ b/impl/src/main/java/com/okta/sdk/impl/client/AbstractClient.java
@@ -21,6 +21,7 @@ import com.okta.sdk.client.AuthenticationScheme;
 import com.okta.sdk.client.Client;
 import com.okta.sdk.client.Proxy;
 import com.okta.sdk.impl.api.ClientCredentialsResolver;
+import com.okta.sdk.impl.config.ClientConfiguration;
 import com.okta.sdk.impl.ds.InternalDataStore;
 import com.okta.sdk.impl.http.authc.RequestAuthenticatorFactory;
 import com.okta.sdk.impl.util.BaseUrlResolver;
@@ -53,6 +54,10 @@ public abstract class AbstractClient extends BaseClient implements Client {
      */
     public AbstractClient(ClientCredentialsResolver clientCredentialsResolver, BaseUrlResolver baseUrlResolver, Proxy proxy, CacheManager cacheManager, AuthenticationScheme authenticationScheme, RequestAuthenticatorFactory requestAuthenticatorFactory, int connectionTimeout) {
         super(clientCredentialsResolver, baseUrlResolver, proxy, cacheManager, authenticationScheme, requestAuthenticatorFactory, connectionTimeout);
+    }
+
+    public AbstractClient(ClientConfiguration clientConfiguration, CacheManager cacheManager) {
+        super(clientConfiguration, cacheManager);
     }
 
     @Override

--- a/impl/src/main/java/com/okta/sdk/impl/client/DefaultClientBuilder.java
+++ b/impl/src/main/java/com/okta/sdk/impl/client/DefaultClientBuilder.java
@@ -205,8 +205,8 @@ public class DefaultClientBuilder implements ClientBuilder {
             clientConfig.setRetryMaxElapsed(Integer.parseInt(props.get(DEFAULT_CLIENT_RETRY_MAX_ELAPSED_PROPERTY_NAME)));
         }
 
-        if (Strings.hasText(props.get(DEFAULT_CLIENT_RETRY_RATE_LIMIT_MAX_OFFSET))) {
-            clientConfig.setRateLimitMaxOffset(Integer.parseInt(props.get(DEFAULT_CLIENT_RETRY_RATE_LIMIT_MAX_OFFSET)));
+        if (Strings.hasText(props.get(DEFAULT_CLIENT_RETRY_MAX_ATTEMPTS_PROPERTY_NAME))) {
+            clientConfig.setRetryMaxAttempts(Integer.parseInt(props.get(DEFAULT_CLIENT_RETRY_MAX_ATTEMPTS_PROPERTY_NAME)));
         }
     }
 
@@ -269,6 +269,12 @@ public class DefaultClientBuilder implements ClientBuilder {
     @Override
     public ClientBuilder setRetryMaxElapsed(int maxElapsed) {
         this.clientConfig.setRetryMaxElapsed(maxElapsed);
+        return this;
+    }
+
+    @Override
+    public ClientBuilder setRetryMaxAttempts(int maxAttempts) {
+        this.clientConfig.setRetryMaxAttempts(maxAttempts);
         return this;
     }
 

--- a/impl/src/main/java/com/okta/sdk/impl/client/DefaultClientBuilder.java
+++ b/impl/src/main/java/com/okta/sdk/impl/client/DefaultClientBuilder.java
@@ -204,6 +204,10 @@ public class DefaultClientBuilder implements ClientBuilder {
         if (Strings.hasText(props.get(DEFAULT_CLIENT_RETRY_MAX_ELAPSED_PROPERTY_NAME))) {
             clientConfig.setRetryMaxElapsed(Integer.parseInt(props.get(DEFAULT_CLIENT_RETRY_MAX_ELAPSED_PROPERTY_NAME)));
         }
+
+        if (Strings.hasText(props.get(DEFAULT_CLIENT_RETRY_RATE_LIMIT_MAX_OFFSET))) {
+            clientConfig.setRateLimitMaxOffset(Integer.parseInt(props.get(DEFAULT_CLIENT_RETRY_RATE_LIMIT_MAX_OFFSET)));
+        }
     }
 
     @Override

--- a/impl/src/main/java/com/okta/sdk/impl/client/DefaultClientBuilder.java
+++ b/impl/src/main/java/com/okta/sdk/impl/client/DefaultClientBuilder.java
@@ -201,8 +201,8 @@ public class DefaultClientBuilder implements ClientBuilder {
             clientConfig.setProxyPassword(props.get(DEFAULT_CLIENT_PROXY_PASSWORD_PROPERTY_NAME));
         }
 
-        if (Strings.hasText(props.get(DEFAULT_CLIENT_RETRY_MAX_ELAPSED_PROPERTY_NAME))) {
-            clientConfig.setRetryMaxElapsed(Integer.parseInt(props.get(DEFAULT_CLIENT_RETRY_MAX_ELAPSED_PROPERTY_NAME)));
+        if (Strings.hasText(props.get(DEFAULT_CLIENT_REQUEST_TIMEOUT_PROPERTY_NAME))) {
+            clientConfig.setRetryMaxElapsed(Integer.parseInt(props.get(DEFAULT_CLIENT_REQUEST_TIMEOUT_PROPERTY_NAME)));
         }
 
         if (Strings.hasText(props.get(DEFAULT_CLIENT_RETRY_MAX_ATTEMPTS_PROPERTY_NAME))) {

--- a/impl/src/main/java/com/okta/sdk/impl/client/DefaultClientBuilder.java
+++ b/impl/src/main/java/com/okta/sdk/impl/client/DefaultClientBuilder.java
@@ -200,6 +200,10 @@ public class DefaultClientBuilder implements ClientBuilder {
         if (Strings.hasText(props.get(DEFAULT_CLIENT_PROXY_PASSWORD_PROPERTY_NAME))) {
             clientConfig.setProxyPassword(props.get(DEFAULT_CLIENT_PROXY_PASSWORD_PROPERTY_NAME));
         }
+
+        if (Strings.hasText(props.get(DEFAULT_CLIENT_RETRY_MAX_ELAPSED_PROPERTY_NAME))) {
+            clientConfig.setRetryMaxElapsed(Integer.parseInt(props.get(DEFAULT_CLIENT_RETRY_MAX_ELAPSED_PROPERTY_NAME)));
+        }
     }
 
     @Override

--- a/impl/src/main/java/com/okta/sdk/impl/config/ClientConfiguration.java
+++ b/impl/src/main/java/com/okta/sdk/impl/config/ClientConfiguration.java
@@ -54,6 +54,7 @@ public class ClientConfiguration {
     private Proxy proxy;
     private BaseUrlResolver baseUrlResolver;
     private int retryMaxElapsed = -1;
+    private int rateLimitMaxOffset = -1;
 
     public String getApiToken() {
         return apiToken;
@@ -231,6 +232,15 @@ public class ClientConfiguration {
         return this;
     }
 
+    public int getRateLimitMaxOffset() {
+        return rateLimitMaxOffset;
+    }
+
+    public ClientConfiguration setRateLimitMaxOffset(int rateLimitMaxOffset) {
+        this.rateLimitMaxOffset = rateLimitMaxOffset;
+        return this;
+    }
+
     @Override
     public String toString() {
         return "ClientConfiguration{" +
@@ -241,6 +251,7 @@ public class ClientConfiguration {
                 ", connectionTimeout=" + connectionTimeout +
                 ", authenticationScheme=" + authenticationScheme +
                 ", retryMaxElapsed=" + retryMaxElapsed +
+                ", rateLimitMaxOffset=" + rateLimitMaxOffset +
                 ", proxy=" + proxy +
                 '}';
     }

--- a/impl/src/main/java/com/okta/sdk/impl/config/ClientConfiguration.java
+++ b/impl/src/main/java/com/okta/sdk/impl/config/ClientConfiguration.java
@@ -18,6 +18,7 @@ package com.okta.sdk.impl.config;
 
 import com.okta.sdk.cache.CacheConfigurationBuilder;
 import com.okta.sdk.client.AuthenticationScheme;
+import com.okta.sdk.client.Proxy;
 import com.okta.sdk.impl.api.ClientCredentialsResolver;
 import com.okta.sdk.impl.http.authc.RequestAuthenticatorFactory;
 import com.okta.sdk.impl.util.BaseUrlResolver;
@@ -50,7 +51,9 @@ public class ClientConfiguration {
     private String proxyHost;
     private String proxyUsername;
     private String proxyPassword;
+    private Proxy proxy;
     private BaseUrlResolver baseUrlResolver;
+    private int retryMaxElapsed = -1;
 
     public String getApiToken() {
         return apiToken;
@@ -197,6 +200,37 @@ public class ClientConfiguration {
         this.baseUrlResolver = baseUrlResolver;
     }
 
+    public Proxy getProxy() {
+        if (this.proxy != null) {
+            return proxy;
+        }
+
+        Proxy proxy = null;
+        // use proxy overrides if they're set
+        if (getProxyPort() > 0 || getProxyHost() != null && (getProxyUsername() == null || getProxyPassword() == null)) {
+            proxy = new Proxy(getProxyHost(), getProxyPort());
+        } else if (getProxyUsername() != null && getProxyPassword() != null) {
+            proxy = new Proxy(getProxyHost(), getProxyPort(), getProxyUsername(), getProxyPassword());
+        }
+
+        this.proxy = proxy;
+        return this.proxy;
+    }
+
+    public ClientConfiguration setProxy(Proxy proxy) {
+        this.proxy = proxy;
+        return this;
+    }
+
+    public int getRetryMaxElapsed() {
+        return retryMaxElapsed;
+    }
+
+    public ClientConfiguration setRetryMaxElapsed(int retryMaxElapsed) {
+        this.retryMaxElapsed = retryMaxElapsed;
+        return this;
+    }
+
     @Override
     public String toString() {
         return "ClientConfiguration{" +
@@ -206,10 +240,8 @@ public class ClientConfiguration {
                 ", baseUrl='" + baseUrl + '\'' +
                 ", connectionTimeout=" + connectionTimeout +
                 ", authenticationScheme=" + authenticationScheme +
-                ", proxyPort=" + proxyPort +
-                ", proxyHost='" + proxyHost + '\'' +
-                ", proxyUsername='" + proxyUsername + '\'' +
-                ", proxyPassword='" + proxyPassword + '\'' +
+                ", retryMaxElapsed=" + retryMaxElapsed +
+                ", proxy=" + proxy +
                 '}';
     }
 }

--- a/impl/src/main/java/com/okta/sdk/impl/config/ClientConfiguration.java
+++ b/impl/src/main/java/com/okta/sdk/impl/config/ClientConfiguration.java
@@ -53,8 +53,8 @@ public class ClientConfiguration {
     private String proxyPassword;
     private Proxy proxy;
     private BaseUrlResolver baseUrlResolver;
-    private int retryMaxElapsed = -1;
-    private int rateLimitMaxOffset = -1;
+    private int retryMaxElapsed = 0;
+    private int retryMaxAttempts = 0;
 
     public String getApiToken() {
         return apiToken;
@@ -232,12 +232,12 @@ public class ClientConfiguration {
         return this;
     }
 
-    public int getRateLimitMaxOffset() {
-        return rateLimitMaxOffset;
+    public int getRetryMaxAttempts() {
+        return retryMaxAttempts;
     }
 
-    public ClientConfiguration setRateLimitMaxOffset(int rateLimitMaxOffset) {
-        this.rateLimitMaxOffset = rateLimitMaxOffset;
+    public ClientConfiguration setRetryMaxAttempts(int retryMaxAttempts) {
+        this.retryMaxAttempts = retryMaxAttempts;
         return this;
     }
 
@@ -251,7 +251,7 @@ public class ClientConfiguration {
                 ", connectionTimeout=" + connectionTimeout +
                 ", authenticationScheme=" + authenticationScheme +
                 ", retryMaxElapsed=" + retryMaxElapsed +
-                ", rateLimitMaxOffset=" + rateLimitMaxOffset +
+                ", retryMaxAttempts=" + retryMaxAttempts +
                 ", proxy=" + proxy +
                 '}';
     }

--- a/impl/src/main/java/com/okta/sdk/impl/http/RequestExecutorFactory.java
+++ b/impl/src/main/java/com/okta/sdk/impl/http/RequestExecutorFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.sdk.impl.http;
+
+import com.okta.sdk.impl.config.ClientConfiguration;
+
+/**
+ * @since 1.2.0
+ */
+public interface RequestExecutorFactory {
+
+    RequestExecutor create(ClientConfiguration clientConfiguration);
+}

--- a/impl/src/main/resources/com/okta/sdk/config/okta.yaml
+++ b/impl/src/main/resources/com/okta/sdk/config/okta.yaml
@@ -30,4 +30,5 @@ okta:
       username:
       password:
     retry:
-      maxElapsed: 65
+      maxElapsed: 70
+      rateLimitMaxOffset: 10

--- a/impl/src/main/resources/com/okta/sdk/config/okta.yaml
+++ b/impl/src/main/resources/com/okta/sdk/config/okta.yaml
@@ -29,3 +29,5 @@ okta:
       host:
       username:
       password:
+    retry:
+      maxElapsed: 180

--- a/impl/src/main/resources/com/okta/sdk/config/okta.yaml
+++ b/impl/src/main/resources/com/okta/sdk/config/okta.yaml
@@ -29,6 +29,6 @@ okta:
       host:
       username:
       password:
-    retry:
-      maxElapsed: 70
-      rateLimitMaxOffset: 10
+    requestTimeout: 0
+    rateLimit:
+      maxRetries: 4

--- a/impl/src/main/resources/com/okta/sdk/config/okta.yaml
+++ b/impl/src/main/resources/com/okta/sdk/config/okta.yaml
@@ -30,4 +30,4 @@ okta:
       username:
       password:
     retry:
-      maxElapsed: 180
+      maxElapsed: 65

--- a/impl/src/test/groovy/com/okta/sdk/impl/http/stub/StubRequestExecutor.groovy
+++ b/impl/src/test/groovy/com/okta/sdk/impl/http/stub/StubRequestExecutor.groovy
@@ -14,16 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.okta.sdk.impl.http.httpclient
+package com.okta.sdk.impl.http.stub
 
-import com.okta.sdk.client.AuthenticationScheme
-import com.okta.sdk.client.Proxy
-import com.okta.sdk.authc.credentials.ClientCredentials
+import com.okta.sdk.impl.config.ClientConfiguration
 import com.okta.sdk.impl.http.Request
 import com.okta.sdk.impl.http.RequestExecutor
 import com.okta.sdk.impl.http.Response
 import com.okta.sdk.impl.http.RestException
-import com.okta.sdk.impl.http.authc.RequestAuthenticatorFactory
 
 /**
  *
@@ -33,14 +30,12 @@ import com.okta.sdk.impl.http.authc.RequestAuthenticatorFactory
  *
  * @since 0.5.0
  */
-public class HttpClientRequestExecutor implements RequestExecutor {
+class StubRequestExecutor implements RequestExecutor {
 
     @Override
-    public Response executeRequest(Request request) throws RestException {
-        return null;
+    Response executeRequest(Request request) throws RestException {
+        return null
     }
 
-    public HttpClientRequestExecutor(ClientCredentials clientCredentials, Proxy proxy, AuthenticationScheme authenticationScheme, RequestAuthenticatorFactory requestAuthenticatorFactory, Integer connectionTimeout) {
-
-    }
+    StubRequestExecutor(ClientConfiguration clientConfiguration) {}
 }

--- a/impl/src/test/groovy/com/okta/sdk/impl/http/stub/StubRequestExecutorFactory.groovy
+++ b/impl/src/test/groovy/com/okta/sdk/impl/http/stub/StubRequestExecutorFactory.groovy
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.sdk.impl.http.stub
+
+import com.okta.sdk.impl.config.ClientConfiguration
+import com.okta.sdk.impl.http.RequestExecutor
+import com.okta.sdk.impl.http.RequestExecutorFactory
+
+public class StubRequestExecutorFactory implements RequestExecutorFactory {
+
+    @Override
+    RequestExecutor create(ClientConfiguration clientConfiguration) {
+        return new StubRequestExecutor(clientConfiguration)
+    }
+}

--- a/impl/src/test/resources/META-INF/services/com.okta.sdk.impl.http.RequestExecutorFactory
+++ b/impl/src/test/resources/META-INF/services/com.okta.sdk.impl.http.RequestExecutorFactory
@@ -1,0 +1,1 @@
+com.okta.sdk.impl.http.stub.StubRequestExecutorFactory

--- a/swagger-templates/src/main/resources/OktaJavaImpl/api.mustache
+++ b/swagger-templates/src/main/resources/OktaJavaImpl/api.mustache
@@ -23,12 +23,12 @@ import com.okta.sdk.impl.api.ClientCredentialsResolver;
 import com.okta.sdk.impl.http.authc.RequestAuthenticatorFactory;
 import com.okta.sdk.impl.util.BaseUrlResolver;
 import com.okta.sdk.impl.http.QueryString;
+import com.okta.sdk.impl.config.ClientConfiguration;
 
 import {{vendorExtensions.overrideApiPackage}}.*;
 
 {{#imports}}import {{import}};
 {{/imports}}
-import com.okta.sdk.impl.client.AbstractClient;
 import com.okta.sdk.impl.ds.InternalDataStore;
 import com.okta.sdk.impl.resource.DefaultVoidResource;
 
@@ -44,10 +44,11 @@ import static com.okta.sdk.lang.Assert.notNull;
 import static com.okta.sdk.lang.Assert.hasText;
 
 {{#operations}}
-    @javax.annotation.Generated(
-            value = "{{generatorClass}}",
-            date  = "{{generatedDate}}")
-    public class {{classname}} extends AbstractClient {
+@javax.annotation.Generated(
+        value = "{{generatorClass}}",
+        date  = "{{generatedDate}}")
+@SuppressWarnings("deprecation")
+public class {{classname}} extends com.okta.sdk.impl.client.AbstractClient {
 
     /**
     * Instantiates a new Client instance that will communicate with the Okta REST API.  See the class-level
@@ -63,7 +64,8 @@ import static com.okta.sdk.lang.Assert.hasText;
     * @param requestAuthenticatorFactory
     * @param connectionTimeout
     */
-    public DefaultClient(ClientCredentialsResolver clientCredentialsResolver,
+    @Deprecated
+    public {{classname}}(ClientCredentialsResolver clientCredentialsResolver,
                          BaseUrlResolver baseUrlResolver,
                          Proxy proxy,
                          CacheManager cacheManager,
@@ -71,6 +73,17 @@ import static com.okta.sdk.lang.Assert.hasText;
                          RequestAuthenticatorFactory requestAuthenticatorFactory,
                          int connectionTimeout) {
         super(clientCredentialsResolver, baseUrlResolver, proxy, cacheManager, authenticationScheme, requestAuthenticatorFactory, connectionTimeout);
+    }
+
+    /**
+    * Instantiates a new Client instance that will communicate with the Okta REST API.  See the class-level
+    * JavaDoc for a usage example.
+    *
+    * @param clientConfiguration  the {@link ClientConfiguration} containing the connection information
+    * @param cacheManager         the {@link CacheManager} that should be used to cache
+    */
+    public {{classname}}(ClientConfiguration clientConfiguration, CacheManager cacheManager) {
+        super(clientConfiguration, cacheManager);
     }
 
 {{#operation}}{{^vendorExtensions.moved}}


### PR DESCRIPTION
Replaces reflection loading of HttpClientRequestExecutor with a factory configured with ServiceLoader
Use `ClientConfiguration` as constructor arg to make method signature more stable (and allow for additional arguments in the future)
Added `okta.client.retry.maxElapsed` configuration

TODO: update configuration for 429 min/max randomization