### PR TITLE
Add `setCredentials` to UserBuilder

### DIFF
--- a/api/src/main/java/com/okta/sdk/resource/user/UserBuilder.java
+++ b/api/src/main/java/com/okta/sdk/resource/user/UserBuilder.java
@@ -59,5 +59,7 @@ public interface UserBuilder {
 
     UserBuilder addGroup(String groupId);
 
+    UserBuilder setCredentials(UserCredentials userCredentials);
+
     User buildAndCreate(Client client);
 }

--- a/impl/src/main/java/com/okta/sdk/impl/resource/DefaultUserBuilder.java
+++ b/impl/src/main/java/com/okta/sdk/impl/resource/DefaultUserBuilder.java
@@ -46,6 +46,7 @@ public class DefaultUserBuilder implements UserBuilder {
     private String mobilePhone;
     private Boolean active;
     private Boolean provider;
+    private UserCredentials userCredentials;
     private Set<String> groupIds = new HashSet<>();
 
     private Map<String, Object> customProfileAttributes = new LinkedHashMap<>();
@@ -132,6 +133,11 @@ public class DefaultUserBuilder implements UserBuilder {
         return this;
     }
 
+    public UserBuilder setCredentials(UserCredentials userCredentials) {
+        this.userCredentials = userCredentials;
+        return this;
+    }
+
     private User build(Client client) {
 
         User user = client.instantiate(User.class);
@@ -160,9 +166,12 @@ public class DefaultUserBuilder implements UserBuilder {
 
         userProfile.putAll(customProfileAttributes);
 
+        if (userCredentials != null) {
+            user.setCredentials(userCredentials);
+        }
+
         if (password != null && password.length > 0 || Strings.hasText(securityQuestion)) {
-            UserCredentials credentials = client.instantiate(UserCredentials.class);
-            user.setCredentials(credentials);
+            UserCredentials credentials = userCredentials(client, user);
 
             if (Strings.hasText(securityQuestion)) {
                 RecoveryQuestionCredential question = client.instantiate(RecoveryQuestionCredential.class);
@@ -178,6 +187,18 @@ public class DefaultUserBuilder implements UserBuilder {
         }
 
         return user;
+    }
+
+    private static UserCredentials userCredentials(Client client, User user) {
+
+        UserCredentials credentials = user.getCredentials();
+
+        if (credentials == null) {
+            credentials = client.instantiate(UserCredentials.class);
+            user.setCredentials(credentials);
+        }
+
+        return credentials;
     }
 
     @Override

--- a/impl/src/test/groovy/com/okta/sdk/impl/resource/UserBuilderTest.groovy
+++ b/impl/src/test/groovy/com/okta/sdk/impl/resource/UserBuilderTest.groovy
@@ -1,0 +1,80 @@
+package com.okta.sdk.impl.resource
+
+import com.okta.sdk.client.Client
+import com.okta.sdk.resource.user.PasswordCredential
+import com.okta.sdk.resource.user.User
+import com.okta.sdk.resource.user.UserCredentials
+import com.okta.sdk.resource.user.UserProfile
+import org.mockito.ArgumentCaptor
+import org.testng.annotations.Test
+
+import static org.mockito.Mockito.*
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.*
+
+
+/**
+ * Tests for {@link com.okta.sdk.resource.user.UserBuilder}.  NOTE: this class is heavily tested through ITs but it
+ * would be nice to get more coverage with UTs.
+ */
+class UserBuilderTest {
+
+    @Test
+    void builderWithCredentialsTest() {
+
+        def client = mock(Client)
+        def userCapture = ArgumentCaptor.forClass(User)
+        def profile = mock(UserProfile)
+        def user = mock(User)
+        def credentials = mock(UserCredentials)
+
+        when(client.instantiate(User)).thenReturn(user)
+        when(client.instantiate(UserProfile)).thenReturn(profile)
+        when(user.getProfile()).thenReturn(profile)
+        when(client.createUser(userCapture.capture(), nullable(Boolean), nullable(Boolean))).thenReturn(user)
+
+        def userResult = new DefaultUserBuilder()
+            .setFirstName("first")
+            .setLastName("last")
+            .setEmail("jcoder@example.com")
+            .setCredentials(credentials)
+            .buildAndCreate(client)
+
+        assertThat userResult, sameInstance(user)
+        def credentialsCapture = ArgumentCaptor.forClass(UserCredentials)
+        verify(user).setCredentials(credentialsCapture.capture())
+    }
+
+    @Test
+    void builderWithCredentialsAndPasswordTest() {
+
+        def password = "aPassword".chars
+        def client = mock(Client)
+        def userCapture = ArgumentCaptor.forClass(User)
+        def profile = mock(UserProfile)
+        def user = mock(User)
+        def credentials = mock(UserCredentials)
+        def passwordCredential = mock(PasswordCredential)
+
+        when(client.instantiate(User)).thenReturn(user)
+        when(client.instantiate(UserProfile)).thenReturn(profile)
+        when(client.instantiate(PasswordCredential)).thenReturn(passwordCredential)
+        when(user.getProfile()).thenReturn(profile)
+        when(client.createUser(userCapture.capture(), nullable(Boolean), nullable(Boolean))).thenReturn(user)
+        when(user.getCredentials()).thenReturn(credentials)
+        when(passwordCredential.setValue(password)).thenReturn(passwordCredential)
+
+        def userResult = new DefaultUserBuilder()
+            .setFirstName("first")
+            .setLastName("last")
+            .setEmail("jcoder@example.com")
+            .setPassword(password)
+            .setCredentials(credentials)
+            .buildAndCreate(client)
+
+        assertThat userResult, sameInstance(user)
+        def credentialsCapture = ArgumentCaptor.forClass(UserCredentials)
+        verify(user).setCredentials(credentialsCapture.capture())
+        verify(credentials).setPassword(passwordCredential)
+    }
+}


### PR DESCRIPTION
Allows for password imports and setting providers while using the UserBuilder

Fixes: #212