### PR TITLE
Update maven to 3.6.0

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.5.2/apache-maven-3.5.2-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.0/apache-maven-3.6.0-bin.zip

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -21,7 +21,6 @@ This project includes:
   commonmark-java core under BSD 2-Clause License
   Commons CLI under The Apache Software License, Version 2.0
   Commons IO under The Apache Software License, Version 2.0
-  Compiler assisted localization library (CAL10N) - API under MIT License
   FindBugs-jsr305 under The Apache Software License, Version 2.0
   Jackson-annotations under The Apache Software License, Version 2.0
   Jackson-core under The Apache Software License, Version 2.0
@@ -41,7 +40,6 @@ This project includes:
   Okta Commons :: Config Check under The Apache License, Version 2.0
   Okta Commons :: Lang under The Apache License, Version 2.0
   SLF4J API Module under MIT License
-  SLF4J Extensions Module under MIT License
   SnakeYAML under Apache License, Version 2.0
   swagger-annotations under Apache License 2.0
   swagger-codegen (core library) under Apache License 2.0

--- a/src/owasp/owasp-suppression.xml
+++ b/src/owasp/owasp-suppression.xml
@@ -33,4 +33,20 @@
        <cve>CVE-2016-6199</cve>
     </suppress>
 
+    <!-- wrong GAV, this CVE effects slf4j-ext not the other slf4j- projects
+     https://nvd.nist.gov/vuln/detail/CVE-2018-8088
+
+     > org.slf4j.ext.EventData in the slf4j-ext module in QOS.CH SLF4J ...
+    -->
+    <suppress>
+        <notes><![CDATA[ file name: slf4j-api-1.7.25.jar ]]></notes>
+        <gav regex="true">^org\.slf4j:slf4j-api:.*$</gav>
+        <cve>CVE-2018-8088</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[ file name: jcl-over-slf4j-1.7.25.jar ]]></notes>
+        <gav regex="true">^org\.slf4j:jcl-over-slf4j:.*$</gav>
+        <cve>CVE-2018-8088</cve>
+    </suppress>
+
 </suppressions>

--- a/swagger-templates/pom.xml
+++ b/swagger-templates/pom.xml
@@ -46,6 +46,10 @@
                     <groupId>com.google.guava</groupId>
                     <artifactId>guava</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-ext</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
- Exclude slf4j-ext dependency in swagger-templates (build time only dependency)
- Exclude OWASP dep-check false positives for other slf4j libs