### PR TITLE
Fix ordering of generated methods body before query

### DIFF
--- a/swagger-templates/src/main/resources/OktaJava/Factor.mustache
+++ b/swagger-templates/src/main/resources/OktaJava/Factor.mustache
@@ -1,0 +1,44 @@
+{{!
+    Copyright 2018-Present Okta, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+}}
+
+    /**
+     * Verify MFA Factor
+     * Verifies an OTP for a &#x60;token&#x60; or &#x60;token:hardware&#x60; factor
+     * @param templateId  (required)
+     * @param body  (required)
+     * @return VerifyFactorResponse
+     * @deprecated use {@link Factor#verify(VerifyFactorRequest, String)}
+    */
+    @javax.annotation.Generated(
+            value    = "com.okta.swagger.codegen.OktaJavaClientApiCodegen",
+            comments = "POST - /api/v1/users/{userId}/factors/{factorId}/verify")
+    @Deprecated
+    VerifyFactorResponse verify(String templateId, VerifyFactorRequest body);
+
+    /**
+    * Verify MFA Factor
+    * Verifies an OTP for a &#x60;token&#x60; or &#x60;token:hardware&#x60; factor
+    * @param templateId  (optional)
+    * @param tokenLifetimeSeconds  (optional, default to 300)
+    * @param body  (required)
+    * @return VerifyFactorResponse
+     * @deprecated use {@link Factor#verify(VerifyFactorRequest, String, Integer)}
+    */
+    @javax.annotation.Generated(
+            value    = "com.okta.swagger.codegen.OktaJavaClientApiCodegen",
+            comments = "POST - /api/v1/users/{userId}/factors/{factorId}/verify")
+    @Deprecated
+    VerifyFactorResponse verify(String templateId, Integer tokenLifetimeSeconds, VerifyFactorRequest body);

--- a/swagger-templates/src/main/resources/OktaJava/User.mustache
+++ b/swagger-templates/src/main/resources/OktaJava/User.mustache
@@ -1,0 +1,62 @@
+{{!
+    Copyright 2018-Present Okta, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+}}
+
+    /**
+     * Enroll Factor
+     * Enrolls a user with a supported factor.
+     * @param updatePhone  (optional, default to false)
+     * @param templateId id of SMS template (only for SMS factor) (optional)
+     * @param tokenLifetimeSeconds  (optional, default to 300)
+     * @param activate  (optional, default to false)
+     * @param body Factor (required)
+     * @return Factor
+     * @deprecated use {@link User#addFactor(Factor, Boolean, String, Integer, Boolean)}
+    */
+    @javax.annotation.Generated(
+            value    = "com.okta.swagger.codegen.OktaJavaClientApiCodegen",
+            comments = "POST - /api/v1/users/{userId}/factors")
+    @Deprecated
+    Factor addFactor(Boolean updatePhone, String templateId, Integer tokenLifetimeSeconds, Boolean activate, Factor body);
+
+    /**
+     * Enroll Factor
+     * Enrolls a user with a supported factor.
+     * @param updatePhone  (optional, default to false)
+     * @param templateId id of SMS template (only for SMS factor) (optional)
+     * @param body Factor (required)
+     * @return Factor
+     * @deprecated use {@link User#addFactor(Factor, Boolean, String)}
+    */
+    @javax.annotation.Generated(
+            value    = "com.okta.swagger.codegen.OktaJavaClientApiCodegen",
+            comments = "POST - /api/v1/users/{userId}/factors")
+    @Deprecated
+    Factor addFactor(Boolean updatePhone, String templateId, Factor body);
+
+    /**
+     * Forgot Password
+     * Generates a one-time token (OTT) that can be used to reset a user&#39;s password.  The user will be required to validate their security question&#39;s answer when visiting the reset link.
+     * This operation can only be performed on users with a valid [recovery question credential](#recovery-question-object) and have an &#x60;ACTIVE&#x60; status.
+     * @param sendEmail  (optional, default to true)
+     * @param userCredentials  (optional)
+     * @return ForgotPasswordResponse
+     * @deprecated use {@link User#forgotPassword(UserCredentials, Boolean)}
+    */
+    @javax.annotation.Generated(
+            value    = "com.okta.swagger.codegen.OktaJavaClientApiCodegen",
+            comments = "POST - /api/v1/users/{userId}/credentials/forgot_password")
+    @Deprecated
+    ForgotPasswordResponse forgotPassword(Boolean sendEmail, UserCredentials userCredentials);

--- a/swagger-templates/src/main/resources/OktaJavaImpl/Factor.mustache
+++ b/swagger-templates/src/main/resources/OktaJavaImpl/Factor.mustache
@@ -1,0 +1,24 @@
+{{!
+    Copyright 2018-Present Okta, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+}}
+    @Override
+    public VerifyFactorResponse verify(String templateId, VerifyFactorRequest body) {
+        return verify(body, templateId);
+    }
+
+    @Override
+    public VerifyFactorResponse verify(String templateId, Integer tokenLifetimeSeconds, VerifyFactorRequest body) {
+        return verify(body, templateId, tokenLifetimeSeconds);
+    }

--- a/swagger-templates/src/main/resources/OktaJavaImpl/User.mustache
+++ b/swagger-templates/src/main/resources/OktaJavaImpl/User.mustache
@@ -1,0 +1,29 @@
+{{!
+    Copyright 2018-Present Okta, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+}}
+    @Override
+    public Factor addFactor(Boolean updatePhone, String templateId, Integer tokenLifetimeSeconds, Boolean activate, Factor body) {
+        return addFactor(body, updatePhone, templateId, tokenLifetimeSeconds, activate);
+    }
+
+    @Override
+    public Factor addFactor(Boolean updatePhone, String templateId, Factor body) {
+        return addFactor(body, updatePhone, templateId);
+    }
+
+    @Override
+    public ForgotPasswordResponse forgotPassword(Boolean sendEmail, UserCredentials userCredentials) {
+        return forgotPassword(userCredentials, sendEmail);
+    }

--- a/swagger-templates/src/main/resources/OktaJavaImpl/modelImpl.mustache
+++ b/swagger-templates/src/main/resources/OktaJavaImpl/modelImpl.mustache
@@ -220,7 +220,7 @@ public class Default{{classname}} extends {{#parent}}{{.}}{{/parent}}{{^parent}}
 
 {{/.}}
 {{/vendorExtensions.operations}}
-
+{{#vendorExtensions.optionalClassnamePartial}}// optional class specific partial{{/vendorExtensions.optionalClassnamePartial}}
 {{/model}}
 {{/models}}
 }


### PR DESCRIPTION
The Client classes methods are already ordered this way, it was just the User and Factor methods that were _wrong_

This change adds the ability to specific a `<Classname>.mustache` file and have it's contents be appended when using the tag: {{#vendorExtensions.optionalClassnamePartial}}
The new User.mustache and Factor.mustache templates include the old (compatible but deprecated) methods which just call the new method