### PR TITLE
Update build to support JDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,27 @@
 language: java
+
 jdk:
 - oraclejdk8
+- openjdk11
+
 addons:
   apt:
     packages:
     - libxml2-utils
+
 before_install:
 - source ./src/ci/before_install.sh
+
+# skip the Travis-CI install phase because Maven handles that directly
 install:
 - 'true'
+
 script:
 - "./src/ci/build.sh"
+
 after_success:
 - bash <(curl -s https://codecov.io/bash) -f coverage/target/site/jacoco-aggregate/jacoco.xml
+
 deploy:
 - provider: pages
   skip_cleanup: true
@@ -23,6 +32,7 @@ deploy:
   on:
     branch: master
     condition: "$TRAVIS_EVENT_TYPE != cron"
+
 notifications:
   slack:
     secure: ivOHHaQvSgTOVi1g/8pvvOigj/gkWdSy23fVTOSejahNO8w6PpVHrVE1mJk29RWFEZlY/xBNqx6Zm0H8XAAVOc12C1tgN2J0RQm4kHXc6t8zMOS5NkuV4V0azP6BdCkcAvBgaks+fx6BYOAzcbHZ7MyV+DrLLmXBQiWFRXL420k=

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -28,6 +28,7 @@ This project includes:
   Jackson-dataformat-YAML under The Apache Software License, Version 2.0
   JavaBeans Activation Framework (JAF) under Common Development and Distribution License (CDDL) v1.0
   JavaMail API jar under CDDL or GPLv2+CE
+  javax.annotation API under CDDL + GPLv2 with classpath exception
   JCL 1.2 implemented over SLF4J under MIT License
   jmustache under The (New) BSD License
   Joda-Time under Apache 2

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -46,6 +46,11 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/httpclients/httpclient/src/main/java/com/okta/sdk/impl/http/httpclient/HttpClientRequestExecutor.java
+++ b/httpclients/httpclient/src/main/java/com/okta/sdk/impl/http/httpclient/HttpClientRequestExecutor.java
@@ -264,17 +264,20 @@ public class HttpClientRequestExecutor extends RetryRequestExecutor {
         HttpEntity entity = getHttpEntity(httpResponse);
 
         InputStream body = entity != null ? entity.getContent() : null;
-        long contentLength = entity != null ? entity.getContentLength() : -1;
+        long contentLength;
 
         //ensure that the content has been fully acquired before closing the http stream
         if (body != null) {
             byte[] bytes = toBytes(entity);
+            contentLength = entity.getContentLength();
 
             if(bytes != null) {
                 body = new ByteArrayInputStream(bytes);
             }  else {
                 body = null;
             }
+        } else {
+            contentLength = 0; // force 0 content length when there is no body
         }
 
         Response response = new DefaultResponse(httpStatus, mediaType, body, contentLength);

--- a/httpclients/okhttp/src/main/java/com/okta/sdk/impl/http/okhttp/OkHttpRequestExecutor.java
+++ b/httpclients/okhttp/src/main/java/com/okta/sdk/impl/http/okhttp/OkHttpRequestExecutor.java
@@ -158,7 +158,7 @@ public class OkHttpRequestExecutor implements RequestExecutor {
 
         ResponseBody body = okResponse.body();
         InputStream bodyInputStream = null;
-        long contentLength = -1;
+        long contentLength;
 
         //ensure that the content has been fully acquired before closing the http stream
         if (body != null) {
@@ -168,6 +168,8 @@ public class OkHttpRequestExecutor implements RequestExecutor {
             if(bytes != null) {
                 bodyInputStream = new ByteArrayInputStream(bytes);
             }
+        } else {
+            contentLength = 0; // force 0 content length when there is no body
         }
 
         Response response = new DefaultResponse(httpStatus, mediaType, bodyInputStream, contentLength);

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -52,6 +52,11 @@
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <!-- Test deps -->
         <dependency>
@@ -62,13 +67,13 @@
         <dependency>
         <groupId>org.powermock</groupId>
             <artifactId>powermock-module-testng</artifactId>
-            <version>1.7.4</version>
+            <version>2.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito2</artifactId>
-            <version>1.7.4</version>
+            <version>2.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/impl/src/main/java/com/okta/sdk/impl/http/support/AbstractHttpMessage.java
+++ b/impl/src/main/java/com/okta/sdk/impl/http/support/AbstractHttpMessage.java
@@ -18,6 +18,7 @@ package com.okta.sdk.impl.http.support;
 
 import com.okta.sdk.impl.http.HttpMessage;
 
+import java.io.IOException;
 import java.io.InputStream;
 
 /**
@@ -28,6 +29,19 @@ public abstract class AbstractHttpMessage implements HttpMessage {
     @Override
     public boolean hasBody() {
         InputStream is = getBody();
-        return is != null && getHeaders().getContentLength() != 0;
+        return is != null
+            && getHeaders().getContentLength() != 0
+            && available(is);
+    }
+
+    private static boolean available(InputStream inputStream) {
+        try {
+            // NOTE: this will NOT work for all input stream types, currently this
+            // project only uses ByteArrayInputStreams which supports 'available' calls
+            return inputStream.available() > 0;
+        } catch (IOException e) {
+            // ignore exception nothing to read
+            return false;
+        }
     }
 }

--- a/impl/src/test/groovy/com/okta/sdk/impl/http/DefaultResponseTest.groovy
+++ b/impl/src/test/groovy/com/okta/sdk/impl/http/DefaultResponseTest.groovy
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.sdk.impl.http
+
+import com.okta.sdk.impl.http.support.DefaultResponse
+import org.testng.annotations.DataProvider
+import org.testng.annotations.Test
+
+import java.nio.charset.StandardCharsets
+
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.is
+
+class DefaultResponseTest {
+
+    @Test(dataProvider = "hasBody-bodyContentExpected")
+    void hasBodyTest(String content, int size, boolean expectedHasBodyResult) {
+        def inputStream = content != null ? new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8.toString())) : null
+        def response = new DefaultResponse(204, MediaType.TEXT_PLAIN, inputStream, size)
+        assertThat "Expected hasBody to return ${expectedHasBodyResult}", response.hasBody(), is(expectedHasBodyResult)
+    }
+
+    @DataProvider(name = "hasBody-bodyContentExpected")
+    static Object[][] hasBodyTestData() {
+      return [
+          ["", -1, false],
+          ["", 0, false],
+          [null, -1, false],
+          [null, 0, false],
+          ["something", 9, true],
+          ["something", -1, true],
+          ["something", 0, false] // This would be a server error, but if the content length is set, use it
+      ]
+   }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,20 @@
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                        <trimStackTrace>false</trimStackTrace>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <configuration>
+                        <trimStackTrace>false</trimStackTrace>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-pmd-plugin</artifactId>
                     <configuration>
                         <excludeRoots>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta</groupId>
         <artifactId>okta-parent</artifactId>
-        <version>13</version>
+        <version>14</version>
         <relativePath>../okta-java-parent</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta</groupId>
         <artifactId>okta-parent</artifactId>
-        <version>10</version>
+        <version>13</version>
         <relativePath>../okta-java-parent</relativePath>
     </parent>
 
@@ -40,7 +40,7 @@
         <snakeyaml.version>1.17</snakeyaml.version>
         <jjwt.version>0.6.0</jjwt.version>
         <okta.sdk.pereviousVersion>1.3.0</okta.sdk.pereviousVersion>
-        <otka.commons.version>1.1.0</otka.commons.version>
+        <otka.commons.version>1.1.1</otka.commons.version>
 
         <github.slug>okta/okta-sdk-java</github.slug>
     </properties>
@@ -97,6 +97,11 @@
                 <groupId>com.okta.commons</groupId>
                 <artifactId>okta-commons-lang</artifactId>
                 <version>${otka.commons.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.annotation</groupId>
+                <artifactId>javax.annotation-api</artifactId>
+                <version>1.3.2</version>
             </dependency>
 
             <!-- ITs -->
@@ -179,7 +184,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>2.7.22</version>
+                <version>2.24.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -288,7 +293,7 @@
                 <plugin>
                     <groupId>com.github.siom79.japicmp</groupId>
                     <artifactId>japicmp-maven-plugin</artifactId>
-                    <version>0.11.1</version>
+                    <version>0.13.0</version>
                     <configuration>
                         <oldVersion>
                             <dependency>

--- a/src/findbugs/findbugs-exclude.xml
+++ b/src/findbugs/findbugs-exclude.xml
@@ -88,6 +88,14 @@
         </Class>
     </Match>
 
+    <!-- only detected when running with Java 11, but this null check IS valid -->
+    <Match>
+        <Class name="com.okta.sdk.impl.config.YAMLPropertiesSource">
+            <Method name="getProperties" />
+            <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
+        </Class>
+    </Match>
+
     <Match>
         <Class name="quickstart.ReadmeSnippets" />]
     </Match>


### PR DESCRIPTION
- minor travis.yaml formatting cleanup
- CI will run against java 8 and 11
- As of java 9 the Generated annotation is not part of the core JDK so javax.annotations was added to the build
- findbugs marks a null check as not needed so it is excluded in findbugs-exclude.xml

NOTE: when running with Java 11 on Travis there were a few IT failures.  I'm not 100% sure they are limited to this environment but I could NOT reproduce it locally.  I was able to code around the problem (and add a test).  It looks like there were http response with an empty body (expected), but in those cases the content length was NOT always getting set to zero.  The result was a content length of `-1` (unknown), and a empty input stream.