### PR TITLE
Fixed regression in HttpClientRequestExecutor failing to retry on SocketException

### DIFF
--- a/httpclients/httpclient/src/main/java/com/okta/sdk/impl/http/httpclient/HttpClientRequestExecutor.java
+++ b/httpclients/httpclient/src/main/java/com/okta/sdk/impl/http/httpclient/HttpClientRequestExecutor.java
@@ -60,6 +60,8 @@ import org.slf4j.LoggerFactory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
 
 /**
  * {@code RequestExecutor} implementation that uses the
@@ -238,10 +240,10 @@ public class HttpClientRequestExecutor extends RetryRequestExecutor {
         try {
             httpResponse = httpClient.execute(httpRequest);
             return toSdkResponse(httpResponse);
-
+        } catch (SocketException | SocketTimeoutException | NoHttpResponseException | ConnectTimeoutException e) {
+            throw new RestException("Unable to execute HTTP request - retryable exception: " + e.getMessage(), e, true);
         } catch (IOException e) {
-            boolean retryable = e instanceof NoHttpResponseException || e instanceof ConnectTimeoutException;
-            throw new RestException("Unable to execute HTTP request: " + e.getMessage(), e, retryable);
+            throw new RestException("Unable to execute HTTP request: " + e.getMessage(), e);
         } finally {
             try {
                 httpResponse.getEntity().getContent().close();

--- a/httpclients/httpclient/src/test/groovy/com/okta/sdk/impl/http/httpclient/HttpClientRequestExecutorStaticConfigTest.groovy
+++ b/httpclients/httpclient/src/test/groovy/com/okta/sdk/impl/http/httpclient/HttpClientRequestExecutorStaticConfigTest.groovy
@@ -18,7 +18,13 @@ package com.okta.sdk.impl.http.httpclient
 import org.testng.IHookCallBack
 import org.testng.IHookable
 import org.testng.ITestResult
+import org.testng.SkipException
 import org.testng.annotations.Test
+
+import java.lang.reflect.Field
+import java.lang.reflect.InvocationTargetException
+import java.lang.reflect.Method
+import java.util.stream.Collectors
 
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.is
@@ -79,6 +85,9 @@ class HttpClientRequestExecutorStaticConfigTest implements IHookable {
         System.setProperties(copy)
         try {
             // run the tests
+            if (!System.getProperty("java.version").startsWith("1.8")) {
+                throw new SkipException("Test test only supported on JDK 8")
+            }
             callBack.runTestMethod(testResult)
 
         } finally {

--- a/httpclients/httpclient/src/test/groovy/com/okta/sdk/impl/http/httpclient/HttpClientRequestExecutorStaticConfigTest.groovy
+++ b/httpclients/httpclient/src/test/groovy/com/okta/sdk/impl/http/httpclient/HttpClientRequestExecutorStaticConfigTest.groovy
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.sdk.impl.http.httpclient
+
+import org.testng.IHookCallBack
+import org.testng.IHookable
+import org.testng.ITestResult
+import org.testng.annotations.Test
+
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.is
+
+class HttpClientRequestExecutorStaticConfigTest implements IHookable {
+
+    private static final String REQUEST_EXECUTOR_CLASSNAME = "com.okta.sdk.impl.http.httpclient.HttpClientRequestExecutor"
+    private static final String VALIDATE_AFTER_INACTIVITY_PROP = "com.okta.sdk.impl.http.httpclient.HttpClientRequestExecutor.connPoolControl.validateAfterInactivity"
+
+    @Test
+    void validateAfterInactivityTo4000() {
+
+        System.properties.setProperty(VALIDATE_AFTER_INACTIVITY_PROP, "4000")
+        def requestExecutor = isolatedClassLoader().loadClass(REQUEST_EXECUTOR_CLASSNAME)
+        assertThat requestExecutor.CONNECTION_VALIDATION_INACTIVITY, is(4000)
+    }
+
+    @Test
+    void validateAfterInactivityDefaultValue() {
+
+        def requestExecutor = isolatedClassLoader().loadClass(REQUEST_EXECUTOR_CLASSNAME)
+        assertThat requestExecutor.CONNECTION_VALIDATION_INACTIVITY, is(5000)
+    }
+
+    @Test
+    void validateAfterInactivityInvalidValue() {
+
+        System.properties.setProperty(VALIDATE_AFTER_INACTIVITY_PROP, "O'Doyle Rules!")
+        def requestExecutor = isolatedClassLoader().loadClass(REQUEST_EXECUTOR_CLASSNAME)
+        assertThat requestExecutor.CONNECTION_VALIDATION_INACTIVITY, is(5000) // default value
+    }
+
+    @Test
+    void validateAfterInactivityIsZero() {
+        System.properties.setProperty(VALIDATE_AFTER_INACTIVITY_PROP, "0")
+        def requestExecutor = isolatedClassLoader().loadClass(REQUEST_EXECUTOR_CLASSNAME)
+        assertThat requestExecutor.CONNECTION_VALIDATION_INACTIVITY, is(0)
+    }
+
+    @Test
+    void validateAfterInactivityIsEmpty() {
+        System.properties.setProperty(VALIDATE_AFTER_INACTIVITY_PROP, "")
+        def requestExecutor = isolatedClassLoader().loadClass(REQUEST_EXECUTOR_CLASSNAME)
+        assertThat requestExecutor.CONNECTION_VALIDATION_INACTIVITY, is(5000) // default value
+    }
+
+    static ClassLoader isolatedClassLoader() {
+        def originalClassLoader = Thread.currentThread().getContextClassLoader()
+        URLClassLoader oldClassLoader = (URLClassLoader) originalClassLoader
+        return new URLClassLoader(oldClassLoader.getURLs(), (ClassLoader) null)
+    }
+
+    @Override
+    void run(IHookCallBack callBack, ITestResult testResult) {
+        def originalProperties = System.getProperties()
+        Properties copy = new Properties()
+        copy.putAll(originalProperties)
+        System.setProperties(copy)
+        try {
+            // run the tests
+            callBack.runTestMethod(testResult)
+
+        } finally {
+            System.setProperties(originalProperties);
+        }
+    }
+}

--- a/httpclients/httpclient/src/test/groovy/com/okta/sdk/impl/http/httpclient/HttpClientRequestExecutorStaticConfigTest.groovy
+++ b/httpclients/httpclient/src/test/groovy/com/okta/sdk/impl/http/httpclient/HttpClientRequestExecutorStaticConfigTest.groovy
@@ -86,7 +86,7 @@ class HttpClientRequestExecutorStaticConfigTest implements IHookable {
         try {
             // run the tests
             if (!System.getProperty("java.version").startsWith("1.8")) {
-                throw new SkipException("Test test only supported on JDK 8")
+                throw new SkipException("Test test only supported on JDK 8, see https://github.com/okta/okta-sdk-java/issues/276")
             }
             callBack.runTestMethod(testResult)
 

--- a/httpclients/httpclient/src/test/groovy/com/okta/sdk/impl/http/httpclient/HttpClientRequestExecutorTest.groovy
+++ b/httpclients/httpclient/src/test/groovy/com/okta/sdk/impl/http/httpclient/HttpClientRequestExecutorTest.groovy
@@ -46,6 +46,9 @@ import org.testng.annotations.Test
 
 import java.nio.charset.StandardCharsets
 import java.text.SimpleDateFormat
+import java.time.Duration
+import java.time.temporal.TemporalUnit
+import java.util.concurrent.TimeUnit
 
 import static org.mockito.Mockito.*
 import static org.hamcrest.MatcherAssert.*
@@ -104,6 +107,8 @@ class HttpClientRequestExecutorTest {
 
         assertThat requestExecutor.maxElapsedMillis, is(2000)
         assertThat requestExecutor.numRetries, is(3)
+        assertThat requestExecutor.httpClient.connManager.pool.timeToLive, is(Duration.ofMinutes(5).toMillis())
+        assertThat requestExecutor.httpClient.connManager.pool.validateAfterInactivity, is(Duration.ofSeconds(2).toMillis() as int)
     }
 
     @Test

--- a/httpclients/httpclient/src/test/resources/logback.xml
+++ b/httpclients/httpclient/src/test/resources/logback.xml
@@ -28,5 +28,7 @@
         <appender-ref ref="STDOUT"/>
     </root>
     <logger name="com.okta.sdk.impl.ds.DefaultDataStore" level="INFO"/>
+    <!-- hide expected WARN messages when running tests -->
+    <logger name="com.okta.sdk.impl.http.httpclient.HttpClientRequestExecutor" level="ERROR"/>
 
 </configuration>

--- a/httpclients/okhttp/src/main/java/com/okta/sdk/impl/http/okhttp/OkHttpRequestExecutor.java
+++ b/httpclients/okhttp/src/main/java/com/okta/sdk/impl/http/okhttp/OkHttpRequestExecutor.java
@@ -44,6 +44,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -142,6 +144,8 @@ public class OkHttpRequestExecutor implements RequestExecutor {
             okhttp3.Response okResponse = client.newCall(okRequestBuilder.build()).execute();
             return toSdkResponse(okResponse);
 
+        } catch (SocketException | SocketTimeoutException e) {
+            throw new RestException("Unable to execute HTTP request - retryable exception: " + e.getMessage(), e, true);
         } catch (IOException e) {
             throw new RestException(e.getMessage(), e);
         }


### PR DESCRIPTION
When the RetryRequestExecutor was pulled out of HttpClientRequestExecutor in 1.4 SocketExceptions and SocketTimeoutExceptions were no longer retried
marked them retryable in the OkHttp implementation

Add configuration for HttpClient's "ValidateAfterInactivity" default of ~5~ 2 seconds (2 is http client's default)

The original implementation of HttpClientRequestExecutor predates this functionality

Updated to set the connection TTL of 5 minutes (which is Okta's DNS ttl). So what we end up with is connections will be reused for 5 minutes, and re-validated every 2 seconds of idle time
(updated after chatting with @cbarbara-okta and @bradhaverstein-okta)