### PR TITLE
Use Google AutoService to generate ServiceLoader files via annotation

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -17,6 +17,9 @@ This project includes:
   Apache Commons Lang under Apache License, Version 2.0
   Apache HttpClient under Apache License, Version 2.0
   Apache HttpCore under Apache License, Version 2.0
+  Auto Common Libraries under Apache 2.0
+  AutoService under Apache 2.0
+  AutoService Processor under Apache 2.0
   Bean Validation API under The Apache Software License, Version 2.0
   commonmark-java core under BSD 2-Clause License
   Commons CLI under The Apache Software License, Version 2.0

--- a/httpclients/httpclient/pom.xml
+++ b/httpclients/httpclient/pom.xml
@@ -58,7 +58,12 @@
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
         </dependency>
-
+        <dependency>
+            <!-- compile time annotation processor -->
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <!-- Test deps -->
         <dependency>

--- a/httpclients/httpclient/src/main/java/com/okta/sdk/impl/http/httpclient/HttpClientRequestExecutorFactory.java
+++ b/httpclients/httpclient/src/main/java/com/okta/sdk/impl/http/httpclient/HttpClientRequestExecutorFactory.java
@@ -18,10 +18,12 @@ package com.okta.sdk.impl.http.httpclient;
 import com.okta.sdk.impl.config.ClientConfiguration;
 import com.okta.sdk.impl.http.RequestExecutor;
 import com.okta.sdk.impl.http.RequestExecutorFactory;
+import com.google.auto.service.AutoService;
 
 /**
  * @since 1.2.0
  */
+@AutoService(RequestExecutorFactory.class)
 public class HttpClientRequestExecutorFactory implements RequestExecutorFactory {
 
     @Override

--- a/httpclients/httpclient/src/main/resources/META-INF/services/com.okta.sdk.impl.http.RequestExecutorFactory
+++ b/httpclients/httpclient/src/main/resources/META-INF/services/com.okta.sdk.impl.http.RequestExecutorFactory
@@ -1,1 +1,0 @@
-com.okta.sdk.impl.http.httpclient.HttpClientRequestExecutorFactory

--- a/httpclients/okhttp/pom.xml
+++ b/httpclients/okhttp/pom.xml
@@ -56,6 +56,12 @@
             <artifactId>jcl-over-slf4j</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <!-- compile time annotation processor -->
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <!-- Test deps -->
         <dependency>

--- a/httpclients/okhttp/src/main/java/com/okta/sdk/impl/http/okhttp/OkHttpRequestExecutorFactory.java
+++ b/httpclients/okhttp/src/main/java/com/okta/sdk/impl/http/okhttp/OkHttpRequestExecutorFactory.java
@@ -19,10 +19,12 @@ import com.okta.sdk.impl.config.ClientConfiguration;
 import com.okta.sdk.impl.http.RequestExecutor;
 import com.okta.sdk.impl.http.RequestExecutorFactory;
 import com.okta.sdk.impl.http.RetryRequestExecutor;
+import com.google.auto.service.AutoService;
 
 /**
  * @since 1.2.0
  */
+@AutoService(RequestExecutorFactory.class)
 public class OkHttpRequestExecutorFactory implements RequestExecutorFactory {
 
     @Override

--- a/httpclients/okhttp/src/main/resources/META-INF/services/com.okta.sdk.impl.http.RequestExecutorFactory
+++ b/httpclients/okhttp/src/main/resources/META-INF/services/com.okta.sdk.impl.http.RequestExecutorFactory
@@ -1,1 +1,0 @@
-com.okta.sdk.impl.http.okhttp.OkHttpRequestExecutorFactory

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -57,6 +57,12 @@
             <artifactId>javax.annotation-api</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <!-- compile time annotation processor -->
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <!-- Test deps -->
         <dependency>

--- a/impl/src/main/java/com/okta/sdk/impl/ds/DefaultResourceFactoryConfig.java
+++ b/impl/src/main/java/com/okta/sdk/impl/ds/DefaultResourceFactoryConfig.java
@@ -17,10 +17,12 @@ package com.okta.sdk.impl.ds;
 
 import java.util.Collections;
 import java.util.Set;
+import com.google.auto.service.AutoService;
 
 /**
  * @since 1.1.0
  */
+@AutoService(ResourceFactoryConfig.class)
 public class DefaultResourceFactoryConfig implements ResourceFactoryConfig {
 
     @Override

--- a/impl/src/main/java/com/okta/sdk/impl/http/support/SdkUserAgentProvider.java
+++ b/impl/src/main/java/com/okta/sdk/impl/http/support/SdkUserAgentProvider.java
@@ -16,10 +16,12 @@
 package com.okta.sdk.impl.http.support;
 
 import com.okta.sdk.http.UserAgentProvider;
+import com.google.auto.service.AutoService;
 
 /**
  * @since 1.1.0
  */
+@AutoService(UserAgentProvider.class)
 public class SdkUserAgentProvider implements UserAgentProvider {
 
     @Override

--- a/impl/src/main/resources/META-INF/services/com.okta.sdk.http.UserAgentProvider
+++ b/impl/src/main/resources/META-INF/services/com.okta.sdk.http.UserAgentProvider
@@ -1,1 +1,0 @@
-com.okta.sdk.impl.http.support.SdkUserAgentProvider

--- a/impl/src/main/resources/META-INF/services/com.okta.sdk.impl.ds.ResourceFactoryConfig
+++ b/impl/src/main/resources/META-INF/services/com.okta.sdk.impl.ds.ResourceFactoryConfig
@@ -1,1 +1,0 @@
-com.okta.sdk.impl.ds.DefaultResourceFactoryConfig

--- a/pom.xml
+++ b/pom.xml
@@ -156,8 +156,12 @@
                 <artifactId>snakeyaml</artifactId>
                 <version>${snakeyaml.version}</version>
             </dependency>
-
-
+            <dependency>
+                <groupId>com.google.auto.service</groupId>
+                <artifactId>auto-service</artifactId>
+                <version>1.0-rc5</version>
+                <optional>true</optional>
+            </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
@@ -351,6 +355,9 @@
                 <inherited>false</inherited>
                 <configuration>
                     <noticeTemplate>${root.dir}/src/license/NOTICE.template</noticeTemplate>
+                    <licenseMapping>
+                        <mapping>${root.dir}/src/license/mapping.xml</mapping>
+                    </licenseMapping>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/license/mapping.xml
+++ b/src/license/mapping.xml
@@ -1,0 +1,75 @@
+<!--
+  ~ Copyright 2017-Present, Okta, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<license-lookup xmlns="https://source.jasig.org/schemas/maven-notice-plugin/license-lookup"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://source.jasig.org/schemas/maven-notice-plugin/license-lookup https://source.jasig.org/schemas/maven-notice-plugin/license-lookup/license-lookup-v1.0.xsd">
+
+    <artifact>
+        <groupId>classworlds</groupId>
+        <artifactId>classworlds</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-archiver</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-container-default</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.osgi</groupId>
+        <artifactId>org.osgi.core</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>antlr</groupId>
+        <artifactId>antlr</artifactId>
+        <license>BSD 3-clause license</license>
+    </artifact>
+    <artifact>
+        <groupId>commons-beanutils</groupId>
+        <artifactId>commons-beanutils</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>dom4j</groupId>
+        <artifactId>dom4j</artifactId>
+        <license>BSD</license>
+    </artifact>
+    <artifact>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-i18n</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>oro</groupId>
+        <artifactId>oro</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>com.google.auto.service</groupId>
+        <artifactId>auto-service</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+</license-lookup>


### PR DESCRIPTION
Generated at compile time instead of manually writing META-INF/services/* files

Needed to override the default license-mapping we use to define the license for Google Auto * which is Apache 2: https://github.com/google/auto/blob/master/LICENSE.txt