### PR TITLE
Make x-headers case insensitive in a ResourceException

### DIFF
--- a/impl/src/main/java/com/okta/sdk/impl/http/HttpHeaders.java
+++ b/impl/src/main/java/com/okta/sdk/impl/http/HttpHeaders.java
@@ -621,7 +621,10 @@ public class HttpHeaders implements MultiValueMap<String, String> {
     public Map<String, List<String>> getXHeaders() {
         return this.headers.entrySet().stream()
                 .filter(e -> e.getKey().toLowerCase(Locale.ENGLISH).startsWith("x-"))
-                .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+                .collect(
+                    LinkedCaseInsensitiveMap::new,
+                    (map, entry) -> map.put(entry.getKey(), entry.getValue()),
+                    Map::putAll);
     }
 
     // Map implementation

--- a/impl/src/test/groovy/com/okta/sdk/impl/http/HttpHeadersTest.groovy
+++ b/impl/src/test/groovy/com/okta/sdk/impl/http/HttpHeadersTest.groovy
@@ -431,5 +431,9 @@ class HttpHeadersTest {
                 hasEntry(is("x-header1"), equalTo(["value1", "value2"])),
                 hasEntry(is("x-header2"), equalTo(["single-value"])),
                 aMapWithSize(2))
+
+        assertThat httpHeaders.getXHeaders().get("x-header1"), equalTo(["value1", "value2"])
+        assertThat httpHeaders.getXHeaders().get("X-HEADER1"), equalTo(["value1", "value2"])
+        assertThat httpHeaders.getXHeaders().get("X-HeADeR2"), equalTo(["single-value"])
     }
 }


### PR DESCRIPTION
HttpHeaders stores headers in a case insensitive map, but the resulting map returned by getXHeaders was using the default toMap collector.