### PR TITLE
Update to openapi spec 1.10

### DIFF
--- a/api/src/main/java/com/okta/sdk/resource/user/UserBuilder.java
+++ b/api/src/main/java/com/okta/sdk/resource/user/UserBuilder.java
@@ -18,8 +18,10 @@ package com.okta.sdk.resource.user;
 import com.okta.commons.lang.Classes;
 import com.okta.sdk.client.Client;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public interface UserBuilder {
 
@@ -54,6 +56,10 @@ public interface UserBuilder {
     UserBuilder putAllProfileProperties(Map<String, Object> profileProperties);
 
     UserBuilder putProfileProperty(String key, Object value);
+
+    default UserBuilder setGroups(String... groupIds) {
+        return setGroups(Arrays.stream(groupIds).collect(Collectors.toSet()));
+    }
 
     UserBuilder setGroups(Set<String> groupIds);
 

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/PasswordPoliciesIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/PasswordPoliciesIT.groovy
@@ -16,19 +16,29 @@
 package com.okta.sdk.tests.it
 
 import com.okta.sdk.client.Client
-import com.okta.sdk.resource.policy.OktaSignOnPolicy
+import com.okta.sdk.resource.group.Group
+import com.okta.sdk.resource.policy.GroupCondition
 import com.okta.sdk.resource.policy.PasswordPolicy
+import com.okta.sdk.resource.policy.PasswordPolicyConditions
 import com.okta.sdk.resource.policy.Policy
+import com.okta.sdk.resource.policy.PolicyPeopleCondition
 import com.okta.sdk.resource.policy.PolicyType
+import com.okta.sdk.tests.it.util.ITSupport
 
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.is
 
-class PasswordPoliciesIT implements CrudTestSupport {
+class PasswordPoliciesIT extends ITSupport implements CrudTestSupport {
 
     @Override
     def create(Client client) {
+        Group group = randomGroup()
+
         return client.createPolicy(client.instantiate(PasswordPolicy)
+            .setConditions(client.instantiate(PasswordPolicyConditions)
+                .setPeople(client.instantiate(PolicyPeopleCondition)
+                    .setGroups(client.instantiate(GroupCondition)
+                        .setInclude([group.getId()]))))
             .setName("policy+" + UUID.randomUUID().toString())
             .setStatus(Policy.StatusEnum.ACTIVE)
             .setDescription("IT created Policy - password CRUD"))

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/PolicyRulesIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/PolicyRulesIT.groovy
@@ -34,23 +34,21 @@ import com.okta.sdk.resource.policy.PolicyPeopleCondition
 import com.okta.sdk.resource.policy.PolicyRule
 import com.okta.sdk.resource.policy.PolicyRuleAuthContextCondition
 import com.okta.sdk.resource.policy.UserCondition
+import com.okta.sdk.tests.it.util.ITSupport
 import org.testng.annotations.Test
 
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.*
 
-class PolicyRulesIT implements CrudTestSupport {
+class PolicyRulesIT extends ITSupport implements CrudTestSupport {
 
     private OktaSignOnPolicy crudTestPolicy
 
     @Override
     def create(Client client) {
 
-        crudTestPolicy = client.createPolicy(client.instantiate(OktaSignOnPolicy)
-            .setName("policy+" + UUID.randomUUID().toString())
-            .setStatus(Policy.StatusEnum.ACTIVE)
-            .setDescription("IT created Policy - CRUD rules"))
-        registerForCleanup(crudTestPolicy)
+        def group = randomGroup()
+        crudTestPolicy = randomSignOnPolicy(group.getId())
 
         def policyRuleName = "policyRule+" + UUID.randomUUID().toString()
         OktaSignOnPolicyRule policyRule = crudTestPolicy.createRule(client.instantiate(OktaSignOnPolicyRule)
@@ -89,11 +87,8 @@ class PolicyRulesIT implements CrudTestSupport {
     @Test
     void activateDeactivateTest() {
 
-        def policy = client.createPolicy(client.instantiate(OktaSignOnPolicy)
-            .setName("policy+" + UUID.randomUUID().toString())
-            .setStatus(Policy.StatusEnum.ACTIVE)
-            .setDescription("IT created Policy - Rules activateDeactivateTest"))
-        registerForCleanup(policy)
+        def group = randomGroup()
+        def policy = randomSignOnPolicy(group.getId())
 
         def policyRuleName = "policyRule+" + UUID.randomUUID().toString()
         OktaSignOnPolicyRule policyRule = policy.createRule(client.instantiate(OktaSignOnPolicyRule)
@@ -119,10 +114,8 @@ class PolicyRulesIT implements CrudTestSupport {
     @Test
     void createPasswordPolicyRule() {
 
-        def policy = client.createPolicy(client.instantiate(PasswordPolicy)
-            .setName("policy+" + UUID.randomUUID().toString())
-            .setDescription("IT created Policy - CRUD rules"))
-        registerForCleanup(policy)
+        def group = randomGroup()
+        def policy = randomPasswordPolicy(group.getId())
 
         def policyRuleName = "policyRule+" + UUID.randomUUID().toString()
         PasswordPolicyRule policyRule = policy.createRule(client.instantiate(PasswordPolicyRule)
@@ -153,10 +146,8 @@ class PolicyRulesIT implements CrudTestSupport {
     @Test
     void createOktaSignOnOnPremPolicyRule() {
 
-        def policy = client.createPolicy(client.instantiate(OktaSignOnPolicy)
-            .setName("policy+" + UUID.randomUUID().toString())
-            .setDescription("IT created Policy - CRUD rules"))
-        registerForCleanup(policy)
+        def group = randomGroup()
+        def policy = randomSignOnPolicy(group.getId())
 
         def policyRuleName = "policyRule+" + UUID.randomUUID().toString()
         OktaSignOnPolicyRule policyRule = policy.createRule(client.instantiate(OktaSignOnPolicyRule)
@@ -187,10 +178,8 @@ class PolicyRulesIT implements CrudTestSupport {
     @Test
     void createOktaSignOnRadiusPolicyRule() {
 
-        def policy = client.createPolicy(client.instantiate(OktaSignOnPolicy)
-            .setName("policy+" + UUID.randomUUID().toString())
-            .setDescription("IT created Policy - CRUD rules"))
-        registerForCleanup(policy)
+        def group = randomGroup()
+        def policy = randomSignOnPolicy(group.getId())
 
         def policyRuleName = "policyRule+" + UUID.randomUUID().toString()
         OktaSignOnPolicyRule policyRule = policy.createRule(client.instantiate(OktaSignOnPolicyRule)
@@ -219,10 +208,8 @@ class PolicyRulesIT implements CrudTestSupport {
     @Test
     void createOktaSignOnCloudPolicyRule() {
 
-        def policy = client.createPolicy(client.instantiate(OktaSignOnPolicy)
-            .setName("policy+" + UUID.randomUUID().toString())
-            .setDescription("IT created Policy - CRUD rules"))
-        registerForCleanup(policy)
+        def group = randomGroup()
+        def policy = randomSignOnPolicy(group.getId())
 
         def policyRuleName = "policyRule+" + UUID.randomUUID().toString()
         OktaSignOnPolicyRule policyRule = policy.createRule(client.instantiate(OktaSignOnPolicyRule)
@@ -269,10 +256,8 @@ class PolicyRulesIT implements CrudTestSupport {
     @Test
     void createOktaSignOnDenyPolicyRule() {
 
-        def policy = client.createPolicy(client.instantiate(OktaSignOnPolicy)
-            .setName("policy+" + UUID.randomUUID().toString())
-            .setDescription("IT created Policy - CRUD rules"))
-        registerForCleanup(policy)
+        def group = randomGroup()
+        def policy = randomSignOnPolicy(group.getId())
 
         def policyRuleName = "policyRule+" + UUID.randomUUID().toString()
         OktaSignOnPolicyRule policyRule = policy.createRule(client.instantiate(OktaSignOnPolicyRule)

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/UsersIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/UsersIT.groovy
@@ -21,6 +21,14 @@ import com.okta.sdk.resource.Resource
 import com.okta.sdk.resource.ResourceException
 import com.okta.sdk.resource.group.Group
 import com.okta.sdk.resource.group.GroupBuilder
+import com.okta.sdk.resource.policy.PasswordPolicyPasswordSettings
+import com.okta.sdk.resource.policy.PasswordPolicyPasswordSettingsAge
+import com.okta.sdk.resource.policy.PasswordPolicyRule
+import com.okta.sdk.resource.policy.PasswordPolicyRuleAction
+import com.okta.sdk.resource.policy.PasswordPolicyRuleActions
+import com.okta.sdk.resource.policy.PasswordPolicyRuleConditions
+import com.okta.sdk.resource.policy.PasswordPolicySettings
+import com.okta.sdk.resource.policy.PolicyNetworkCondition
 import com.okta.sdk.resource.user.AuthenticationProviderType
 import com.okta.sdk.resource.user.ChangePasswordRequest
 import com.okta.sdk.resource.user.ForgotPasswordResponse
@@ -39,12 +47,13 @@ import org.testng.Assert
 import org.testng.annotations.BeforeClass
 import org.testng.annotations.Test
 
+import java.time.Duration
 import java.util.stream.Collectors
 
 import static com.okta.sdk.tests.it.util.Util.assertGroupTargetPresent
 import static com.okta.sdk.tests.it.util.Util.assertNotPresent
 import static com.okta.sdk.tests.it.util.Util.assertPresent
-import static com.okta.sdk.tests.it.util.Util.getExpect
+import static com.okta.sdk.tests.it.util.Util.expect
 import static com.okta.sdk.tests.it.util.Util.validateGroup
 import static com.okta.sdk.tests.it.util.Util.validateUser
 import static org.hamcrest.MatcherAssert.assertThat
@@ -250,7 +259,67 @@ class UsersIT extends ITSupport implements CrudTestSupport {
         // 2. Change the user's password
         UserCredentials credentials = user.changePassword(client.instantiate(ChangePasswordRequest)
             .setOldPassword(client.instantiate(PasswordCredential).setValue('Abcd1234'.toCharArray()))
-            .setNewPassword(client.instantiate(PasswordCredential).setValue('1234Abcd'.toCharArray())))
+            .setNewPassword(client.instantiate(PasswordCredential).setValue('1234Abcd'.toCharArray())), true)
+        assertThat credentials.getProvider().getType(), equalTo(AuthenticationProviderType.OKTA)
+
+        // 3. make the test recording happy, and call a get on the user
+        // TODO: fix har file
+        client.getUser(user.getId())
+    }
+
+    @Test
+    void changeStrictPasswordTest() {
+
+        def password = 'Abcd1234'
+        def firstName = 'John'
+        def lastName = 'Change-Password'
+        def email = "john-${uniqueTestName}@example.com"
+
+        def group = randomGroup()
+        def policy = randomPasswordPolicy(group.getId())
+        policy.setSettings(client.instantiate(PasswordPolicySettings)
+            .setPassword(client.instantiate(PasswordPolicyPasswordSettings)
+                .setAge(client.instantiate(PasswordPolicyPasswordSettingsAge)
+                    .setMinAgeMinutes(Duration.ofDays(2L).toMinutes() as int))))
+            .update()
+
+        def policyRuleName = "policyRule+" + UUID.randomUUID().toString()
+        PasswordPolicyRule policyRule = policy.createRule(client.instantiate(PasswordPolicyRule)
+            .setConditions(client.instantiate(PasswordPolicyRuleConditions)
+                .setNetwork(client.instantiate(PolicyNetworkCondition)
+                    .setConnection(PolicyNetworkCondition.ConnectionEnum.ANYWHERE)))
+                .setActions(client.instantiate(PasswordPolicyRuleActions)
+                    .setPasswordChange(client.instantiate(PasswordPolicyRuleAction)
+                        .setAccess(PasswordPolicyRuleAction.AccessEnum.ALLOW))
+                    .setSelfServicePasswordReset(client.instantiate(PasswordPolicyRuleAction)
+                        .setAccess(PasswordPolicyRuleAction.AccessEnum.ALLOW))
+                    .setSelfServiceUnlock(client.instantiate(PasswordPolicyRuleAction)
+                        .setAccess(PasswordPolicyRuleAction.AccessEnum.DENY)))
+            .setName(policyRuleName))
+        registerForCleanup(policyRule)
+
+        // 1. Create a user
+        User user = UserBuilder.instance()
+                .setEmail(email)
+                .setFirstName(firstName)
+                .setLastName(lastName)
+                .setPassword(password.toCharArray())
+                .setActive(true)
+                .setGroups(group.getId())
+                .buildAndCreate(client)
+        registerForCleanup(user)
+        validateUser(user, firstName, lastName, email)
+
+        // 2. Change the user's password
+        def request = client.instantiate(ChangePasswordRequest)
+            .setOldPassword(client.instantiate(PasswordCredential).setValue('Abcd1234'.toCharArray()))
+            .setNewPassword(client.instantiate(PasswordCredential).setValue('1234Abcd'.toCharArray()))
+
+        //
+        def exception = expect ResourceException, {user.changePassword(request, true)}
+        assertThat exception.getMessage(), containsString("E0000014") // Update of credentials failed.
+
+        def credentials = user.changePassword(request, false)
         assertThat credentials.getProvider().getType(), equalTo(AuthenticationProviderType.OKTA)
 
         // 3. make the test recording happy, and call a get on the user

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/UsersIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/UsersIT.groovy
@@ -315,7 +315,6 @@ class UsersIT extends ITSupport implements CrudTestSupport {
             .setOldPassword(client.instantiate(PasswordCredential).setValue('Abcd1234'.toCharArray()))
             .setNewPassword(client.instantiate(PasswordCredential).setValue('1234Abcd'.toCharArray()))
 
-        //
         def exception = expect ResourceException, {user.changePassword(request, true)}
         assertThat exception.getMessage(), containsString("E0000014") // Update of credentials failed.
 

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/util/ITSupport.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/util/ITSupport.groovy
@@ -16,6 +16,15 @@
 package com.okta.sdk.tests.it.util
 
 import com.okta.sdk.client.Client
+import com.okta.sdk.resource.group.Group
+import com.okta.sdk.resource.group.GroupBuilder
+import com.okta.sdk.resource.policy.GroupCondition
+import com.okta.sdk.resource.policy.OktaSignOnPolicy
+import com.okta.sdk.resource.policy.OktaSignOnPolicyConditions
+import com.okta.sdk.resource.policy.PasswordPolicy
+import com.okta.sdk.resource.policy.PasswordPolicyConditions
+import com.okta.sdk.resource.policy.Policy
+import com.okta.sdk.resource.policy.PolicyPeopleCondition
 import com.okta.sdk.resource.user.User
 import com.okta.sdk.resource.user.UserBuilder
 import com.okta.sdk.tests.Scenario
@@ -76,5 +85,50 @@ abstract class ITSupport implements ClientProvider {
         registerForCleanup(user)
 
         return user
+    }
+
+    Group randomGroup(String name = "group-${UUID.randomUUID().toString()}") {
+
+        Group group = GroupBuilder.instance()
+            .setName(name)
+            .setDescription(name)
+            .buildAndCreate(getClient())
+        registerForCleanup(group)
+
+        return group
+    }
+
+    PasswordPolicy randomPasswordPolicy(String groupId) {
+
+        PasswordPolicy policy = client.createPolicy(client.instantiate(PasswordPolicy)
+            .setConditions(client.instantiate(PasswordPolicyConditions)
+                .setPeople(client.instantiate(PolicyPeopleCondition)
+                    .setGroups(client.instantiate(GroupCondition)
+                        .setInclude([groupId]))))
+            .setName("policy+" + UUID.randomUUID().toString())
+            .setStatus(Policy.StatusEnum.ACTIVE)
+            .setDescription("IT created Policy")
+            .setStatus(Policy.StatusEnum.ACTIVE))
+
+        registerForCleanup(policy)
+
+        return policy
+    }
+
+    OktaSignOnPolicy randomSignOnPolicy(String groupId) {
+
+        OktaSignOnPolicy policy = client.createPolicy(client.instantiate(OktaSignOnPolicy)
+            .setConditions(client.instantiate(OktaSignOnPolicyConditions)
+                .setPeople(client.instantiate(PolicyPeopleCondition)
+                    .setGroups(client.instantiate(GroupCondition)
+                        .setInclude([groupId]))))
+            .setName("policy+" + UUID.randomUUID().toString())
+            .setStatus(Policy.StatusEnum.ACTIVE)
+            .setDescription("IT created Policy")
+            .setStatus(Policy.StatusEnum.ACTIVE))
+
+        registerForCleanup(policy)
+
+        return policy
     }
 }

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/util/ITSupport.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/util/ITSupport.groovy
@@ -87,7 +87,7 @@ abstract class ITSupport implements ClientProvider {
         return user
     }
 
-    Group randomGroup(String name = "group-${UUID.randomUUID().toString()}") {
+    Group randomGroup(String name = "group-java-sdk-${UUID.randomUUID().toString()}") {
 
         Group group = GroupBuilder.instance()
             .setName(name)
@@ -105,7 +105,7 @@ abstract class ITSupport implements ClientProvider {
                 .setPeople(client.instantiate(PolicyPeopleCondition)
                     .setGroups(client.instantiate(GroupCondition)
                         .setInclude([groupId]))))
-            .setName("policy+" + UUID.randomUUID().toString())
+            .setName("policy-java-" + UUID.randomUUID().toString())
             .setStatus(Policy.StatusEnum.ACTIVE)
             .setDescription("IT created Policy")
             .setStatus(Policy.StatusEnum.ACTIVE))
@@ -122,7 +122,7 @@ abstract class ITSupport implements ClientProvider {
                 .setPeople(client.instantiate(PolicyPeopleCondition)
                     .setGroups(client.instantiate(GroupCondition)
                         .setInclude([groupId]))))
-            .setName("policy+" + UUID.randomUUID().toString())
+            .setName("policy-java-" + UUID.randomUUID().toString())
             .setStatus(Policy.StatusEnum.ACTIVE)
             .setDescription("IT created Policy")
             .setStatus(Policy.StatusEnum.ACTIVE))

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/util/Util.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/util/Util.groovy
@@ -136,14 +136,15 @@ class Util {
         }
     }
 
-    static def expect = { Class<? extends Throwable> catchMe, Closure callMe ->
+    static <T extends Throwable> T expect(Class<T> catchMe, Closure closure) {
         try {
-            callMe.call()
+            closure.call()
             Assert.fail("Expected ${catchMe.getName()} to be thrown.")
         } catch(e) {
             if (!e.class.isAssignableFrom(catchMe)) {
                 throw e
             }
+            return e
         }
     }
 }

--- a/src/swagger/api.yaml
+++ b/src/swagger/api.yaml
@@ -25,7 +25,7 @@ info:
   license:
     name: Apache-2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
-  version: 1.9.0
+  version: 1.10.0
 externalDocs:
   description: Find more info here
   url: 'http://developer.okta.com/docs/api/getting_started/design_principles.html'
@@ -808,6 +808,7 @@ paths:
     put:
       consumes:
         - application/json
+      description: Success
       operationId: updateRule
       parameters:
         - in: path
@@ -1705,6 +1706,10 @@ paths:
           name: userId
           required: true
           type: string
+        - in: query
+          name: strict
+          type: boolean
+          x-okta-added-version: 1.10.0
       produces:
         - application/json
       responses:
@@ -1768,6 +1773,10 @@ paths:
           name: userId
           required: true
           type: string
+        - in: query
+          name: strict
+          type: boolean
+          x-okta-added-version: 1.10.0
       produces:
         - application/json
       responses:
@@ -2403,7 +2412,7 @@ paths:
       produces:
         - application/json
       responses:
-        '200':
+        '201':
           description: Success
           schema:
             $ref: '#/definitions/Role'
@@ -2439,6 +2448,7 @@ paths:
     get:
       consumes:
         - application/json
+      description: Success
       operationId: listGroupTargetsForRole
       parameters:
         - in: path
@@ -2474,6 +2484,7 @@ paths:
     delete:
       consumes:
         - application/json
+      description: Success
       operationId: removeGroupTargetFromRole
       parameters:
         - in: path
@@ -2500,6 +2511,7 @@ paths:
     put:
       consumes:
         - application/json
+      description: Success
       operationId: addGroupTargetToRole
       parameters:
         - in: path
@@ -2936,6 +2948,8 @@ definitions:
         $ref: '#/definitions/ApplicationSettingsApplication'
       implicitAssignment:
         type: boolean
+      inlineHookId:
+        type: string
       notifications:
         $ref: '#/definitions/ApplicationSettingsNotifications'
     type: object
@@ -3223,6 +3237,7 @@ definitions:
         type: string
       mfaStateTokenId:
         type: string
+        x-okta-deprecated: 1.10.0
       profile:
         $ref: '#/definitions/FactorProfile'
       provider:
@@ -4441,13 +4456,10 @@ definitions:
     properties:
       delegation:
         $ref: '#/definitions/PasswordPolicyDelegationSettings'
-        readOnly: true
       password:
         $ref: '#/definitions/PasswordPolicyPasswordSettings'
-        readOnly: true
       recovery:
         $ref: '#/definitions/PasswordPolicyRecoverySettings'
-        readOnly: true
     type: object
     x-okta-tags:
       - Policy
@@ -4702,6 +4714,16 @@ definitions:
           type: object
         readOnly: true
         type: object
+      _links:
+        additionalProperties:
+          type: object
+        readOnly: true
+        type: object
+      assignmentType:
+        enum:
+          - GROUP
+          - USER
+        type: string
       created:
         format: date-time
         readOnly: true


### PR DESCRIPTION
- Add IT to validate updating a users password with `strict` set
- Add setGroups(String... groupIds) to UserBuilder (simplifies testing)
- Update policies created in ITs to scope to users of a group (so tests can run in parallel)
- abstract randomGroup and random*Policy IT logic to ITSupport class