### PR TITLE
Update Jackson-databind to 2.9.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,20 @@
     <dependencyManagement>
         <dependencies>
 
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <!-- Once 2.9.9.1 is included in the next version of the jackson-bom, this next dep can be removed -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.9.9.1</version>
+            </dependency>
+
             <!-- Inter project dependencies -->
             <dependency>
                 <groupId>com.okta.sdk</groupId>
@@ -147,11 +161,6 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
                 <version>${snakeyaml.version}</version>
@@ -196,24 +205,6 @@
                 <artifactId>slf4j-simple</artifactId>
                 <version>${slf4j.version}</version>
                 <scope>test</scope>
-            </dependency>
-
-            <!-- transitive dependency versions updated due to owasp scan -->
-
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-core</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.dataformat</groupId>
-                <artifactId>jackson-dataformat-yaml</artifactId>
-                <version>${jackson.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/src/owasp/owasp-suppression.xml
+++ b/src/owasp/owasp-suppression.xml
@@ -90,4 +90,11 @@
         <cve>CVE-2018-20200</cve>
     </suppress>
 
+    <!-- build time dependency contains older version of gradle -->
+    <suppress>
+        <notes><![CDATA[ file name: swagger-codegen-2.2.3.jar: gradle-wrapper.jar ]]></notes>
+        <sha1>0f6f1fa2b59ae770ca14f975726bed8d6620ed9b</sha1>
+        <cve>CVE-2019-11065</cve>
+    </suppress>
+
 </suppressions>


### PR DESCRIPTION
Works around jackson-databind 2.9.9.1 not being available in the jackson-bom yet

also suppresses warning of a build time dep on Gradle (pulled in via swagger)