### PR TITLE
switching to openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-- oraclejdk8
+- openjdk8
 - openjdk11
 
 addons:
@@ -30,7 +30,7 @@ deploy:
   email: developers@okta.com
   name: Travis CI - Auto Doc Build
   on:
-    jdk: oraclejdk8
+    jdk: openjdk8
     branch: master
     condition: "$TRAVIS_EVENT_TYPE != cron"
 


### PR DESCRIPTION
Lately installing oraclejdk8 on Travis-CI has been failing.

Nowadays OpenJDK works great, so we can just switch to that