### PR TITLE
Improved request retry reliability when a max threashold is NOT set

### DIFF
--- a/impl/src/main/java/com/okta/sdk/impl/http/RetryRequestExecutor.java
+++ b/impl/src/main/java/com/okta/sdk/impl/http/RetryRequestExecutor.java
@@ -179,7 +179,10 @@ public class RetryRequestExecutor implements RequestExecutor {
 
         // default / fallback strategy (backwards compatible implementation)
         if (delay < 0) {
-            delay = Math.min(getDefaultDelayMillis(retries), timeElapsedLeft);
+            // if maxElapsedMillis is disabled (i.e. < 0, then we can ONLY use the default delay strategy
+            delay = maxElapsedMillis <= 0
+                ? getDefaultDelayMillis(retries)
+                : Math.min( getDefaultDelayMillis(retries), timeElapsedLeft);
         }
 
         // this shouldn't happen, but guard against a negative delay at this point

--- a/impl/src/test/groovy/com/okta/sdk/impl/http/RetryRequestExecutorTest.groovy
+++ b/impl/src/test/groovy/com/okta/sdk/impl/http/RetryRequestExecutorTest.groovy
@@ -213,6 +213,34 @@ class RetryRequestExecutorTest {
     }
 
     @Test
+    void testSimulatedConnectionResetAndRetryOnlyMaxRetries() {
+
+        def requestExecutor = createRequestExecutor()
+        requestExecutor.numRetries = 4
+        requestExecutor.maxElapsedMillis = 0
+        def httpResponse = stubResponse("mock error", 400)
+
+        long currentTime = System.currentTimeMillis()
+        requestExecutor.pauseBeforeRetry(1, httpResponse, 31L)
+        long endTime = System.currentTimeMillis()
+        assertThat endTime - currentTime, greaterThanOrEqualTo(600L) // the first delay is 600ms
+    }
+
+    @Test
+    void testSimulatedConnectionResetAndRetryOnlyMaxMillis() {
+
+        def requestExecutor = createRequestExecutor()
+        requestExecutor.numRetries = 0
+        requestExecutor.maxElapsedMillis = 100
+        def httpResponse = stubResponse("mock error", 400)
+
+        long currentTime = System.currentTimeMillis()
+        requestExecutor.pauseBeforeRetry(1, httpResponse, 30L)
+        long endTime = System.currentTimeMillis()
+        assertThat endTime - currentTime, greaterThanOrEqualTo(70L) // Delay once to fit the window of `maxElapsed - actualTimeElapsed` 100 - 30 = 70
+    }
+
+    @Test
     void test429RetryHeadersMissing() {
 
         HttpHeaders headers = new HttpHeaders()


### PR DESCRIPTION
the RequestRetryExecutor will now correctly ignore the elapsed time when calculate the delay when `okta.client.requestTimeout` is not set