### PR TITLE
WIP: Support OAuth access token ClientCredentials impl

### DIFF
--- a/api/src/main/java/com/okta/sdk/authc/credentials/OAuth2ClientCredentials.java
+++ b/api/src/main/java/com/okta/sdk/authc/credentials/OAuth2ClientCredentials.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.sdk.authc.credentials;
+
+public class OAuth2ClientCredentials implements ClientCredentials<String> {
+
+    private static ThreadLocal<String> ACCESS_TOKEN = new ThreadLocal<>(); // TODO this might not be the best strategy, need to make sure we doc how to use and explain the importance of cleaning up after a request
+
+    @Override
+    public String getCredentials() {
+        return ACCESS_TOKEN.get();
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.ACCESS_TOKEN.set(accessToken);
+    }
+
+    public void clearAccessToken() {
+        this.ACCESS_TOKEN.remove();
+    }
+}

--- a/api/src/main/java/com/okta/sdk/client/AuthenticationScheme.java
+++ b/api/src/main/java/com/okta/sdk/client/AuthenticationScheme.java
@@ -34,6 +34,7 @@ import com.okta.commons.lang.Assert;
 public enum AuthenticationScheme {
 
     SSWS("com.okta.sdk.impl.http.authc.SswsAuthenticator"), //SSWS Authentication
+    OAUTH2("com.okta.sdk.impl.http.authc.OAuth2RequestAuthenticator"), // OAuth2 access token
     NONE(DisabledAuthenticator.class);
 
     private final String requestAuthenticatorClassName;

--- a/impl/src/main/java/com/okta/sdk/impl/http/authc/OAuth2RequestAuthenticator.java
+++ b/impl/src/main/java/com/okta/sdk/impl/http/authc/OAuth2RequestAuthenticator.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.sdk.impl.http.authc;
+
+import com.okta.commons.http.Request;
+import com.okta.commons.http.authc.RequestAuthenticator;
+import com.okta.commons.lang.Assert;
+import com.okta.commons.lang.Strings;
+import com.okta.sdk.authc.credentials.ClientCredentials;
+
+public class OAuth2RequestAuthenticator implements RequestAuthenticator {
+
+    public static final String AUTHENTICATION_SCHEME = "OAUTH2";
+
+    private final ClientCredentials<String> clientCredentials;
+
+    public OAuth2RequestAuthenticator(ClientCredentials<String> clientCredentials) {
+        Assert.notNull(clientCredentials, "clientCredentials must be not be null.");
+        this.clientCredentials = clientCredentials;
+    }
+
+    @Override
+    public void authenticate(Request request) {
+
+        String accessToken = clientCredentials.getCredentials();
+        if (Strings.hasText(accessToken)) {
+            request.getHeaders().set(AUTHORIZATION_HEADER, "Bearer " + accessToken);
+        }
+        // TODO should we fail?, there are a few publicly readable endpoints
+    }
+}


### PR DESCRIPTION
Quick attempt supporting access token for authentication.
It basically _just works_ but we probably need a sperate set of tests
The current ITs set up a lot of structures and require more access than what they are actually testing.

There is no way for the SDK to obtain an access token (which is fine, that would likely be configured through some other integration)

This impl also depends on a ThreadLocal usage which may or may not be correct depending on the use case, so we would need to document (and likely provide a wrapper) to make sure any access tokens were cleaned up for the thread, maybe something like:

```java
client.withAccessToken(accessToken, (client) -> {
  // do stuff with the client here
  client.getUsers();
} );
```