### PR TITLE
Updates test to use unique resource name

### DIFF
--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/GroupRulesIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/GroupRulesIT.groovy
@@ -152,7 +152,7 @@ class GroupRulesIT implements CrudTestSupport {
         // 4. Deactivate the rule and update it
         rule.deactivate()
 
-        rule.name = 'Test group rule updated'
+        rule.name = 'Test group rule updated ${uniqueTestName}'
         rule.getConditions().getExpression().value = 'user.lastName==\"incorrect\"'
         rule.update()
         rule.activate()


### PR DESCRIPTION
* Fixes the following IT error during cron runs 
```
[ERROR] Tests run: 69, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 201.871 s <<< FAILURE! - in TestSuite
[ERROR] groupRuleCrudTest(com.okta.sdk.tests.it.GroupRulesIT)  Time elapsed: 2.925 s  <<< FAILURE!
com.okta.sdk.resource.ResourceException: HTTP 400, Okta E0000001 (Api validation failed: name - name: Policy rule name already in use), ErrorId oae0L7IoLa8RvOq0AanAwj6DA
```