### PR TITLE
Minor change to allow reading in scopes from YAML list

### DIFF
--- a/impl/src/main/java/com/okta/sdk/impl/client/DefaultClientBuilder.java
+++ b/impl/src/main/java/com/okta/sdk/impl/client/DefaultClientBuilder.java
@@ -231,7 +231,7 @@ public class DefaultClientBuilder implements ClientBuilder {
         }
 
         if (Strings.hasText(props.get(DEFAULT_CLIENT_SCOPES_PROPERTY_NAME))) {
-            Set<String> scopes = new HashSet<>(Arrays.asList(props.get(DEFAULT_CLIENT_SCOPES_PROPERTY_NAME).split(" ")));
+            Set<String> scopes = new HashSet<>(Arrays.asList(props.get(DEFAULT_CLIENT_SCOPES_PROPERTY_NAME).split("[\\s,]+")));
             clientConfig.setScopes(scopes);
         }
 


### PR DESCRIPTION
I encountered an issue using the okta.yaml and OAuth 2.0 and specifying multiple scopes.  The DefaultClientBuilder assumes that the scopes will be space delimited but the YAMLPropertiesSource loads the scopes into a comma delimited property.  I made a slight change to accommodate space and comma delimited scopes properties.