### PR TITLE
Allow OKTA_CLIENT_CONNECTIONTIMEOUT to be set

### DIFF
--- a/impl/src/test/groovy/com/okta/sdk/impl/client/DefaultClientBuilderTest.groovy
+++ b/impl/src/test/groovy/com/okta/sdk/impl/client/DefaultClientBuilderTest.groovy
@@ -89,7 +89,7 @@ class DefaultClientBuilderTest {
         def builder = new DefaultClientBuilder(noDefaultYamlResourceFactory())
         DefaultClientBuilder clientBuilder = (DefaultClientBuilder) builder
         assertEquals clientBuilder.clientConfiguration.baseUrl, "https://api.okta.com/v42"
-        assertEquals clientBuilder.clientConfiguration.connectionTimeout, 10
+        assertEquals clientBuilder.clientConfiguration.connectionTimeout, 100
         assertEquals clientBuilder.clientConfiguration.authenticationScheme, AuthenticationScheme.SSWS
     }
 

--- a/impl/src/test/groovy/com/okta/sdk/impl/client/DefaultClientBuilderTest.groovy
+++ b/impl/src/test/groovy/com/okta/sdk/impl/client/DefaultClientBuilderTest.groovy
@@ -61,6 +61,7 @@ class DefaultClientBuilderTest {
         System.clearProperty("okta.client.clientId")
         System.clearProperty("okta.client.scopes")
         System.clearProperty("okta.client.privateKey")
+        System.clearProperty("okta.client.connectionTimeout")
 
         RestoreEnvironmentVariables.setEnvironmentVariable("OKTA_CLIENT_TOKEN", null)
         RestoreEnvironmentVariables.setEnvironmentVariable("OKTA_CLIENT_ORGURL", null)
@@ -68,6 +69,7 @@ class DefaultClientBuilderTest {
         RestoreEnvironmentVariables.setEnvironmentVariable("OKTA_CLIENT_CLIENTID", null)
         RestoreEnvironmentVariables.setEnvironmentVariable("OKTA_CLIENT_SCOPES", null)
         RestoreEnvironmentVariables.setEnvironmentVariable("OKTA_CLIENT_PRIVATEKEY", null)
+        RestoreEnvironmentVariables.setEnvironmentVariable("OKTA_CLIENT_CONNECTIONTIMEOUT", null)
     }
 
     @Test

--- a/impl/src/test/groovy/com/okta/sdk/impl/client/DefaultClientBuilderTest.groovy
+++ b/impl/src/test/groovy/com/okta/sdk/impl/client/DefaultClientBuilderTest.groovy
@@ -89,7 +89,7 @@ class DefaultClientBuilderTest {
         def builder = new DefaultClientBuilder(noDefaultYamlResourceFactory())
         DefaultClientBuilder clientBuilder = (DefaultClientBuilder) builder
         assertEquals clientBuilder.clientConfiguration.baseUrl, "https://api.okta.com/v42"
-        assertEquals clientBuilder.clientConfiguration.connectionTimeout, 100
+        assertEquals clientBuilder.clientConfiguration.connectionTimeout, 10
         assertEquals clientBuilder.clientConfiguration.authenticationScheme, AuthenticationScheme.SSWS
     }
 


### PR DESCRIPTION
**Background:**

Since we have lot of flaky ITs that break due to high back end Okta core API latency, we should increase the client connection timeout to prevent IT failures in Oktapreview test org. This timeout value could be reduced if we migrate to prod org (which is planned).

This should be effected in PDVs also to prevent the frequent IT failures.

**What is done:**

1. Updated the timeout setting in Travis config already (env variable OKTA_CLIENT_CONNECTIONTIMEOUT is set to 100).

<img width="1328" alt="image" src="https://user-images.githubusercontent.com/61501885/83823628-47968a80-a689-11ea-91eb-e877d9dd3639.png">

2. Due to the above setting, there is this test (in PR) that fails. We need to reset this environment variable before running this unit test and restore it later. 