### PR TITLE
Add setter for UserType property in UserBuilder

### DIFF
--- a/api/src/main/java/com/okta/sdk/resource/user/UserBuilder.java
+++ b/api/src/main/java/com/okta/sdk/resource/user/UserBuilder.java
@@ -51,6 +51,8 @@ public interface UserBuilder {
 
     UserBuilder setProvider(Boolean provider);
 
+    UserBuilder setType(UserType userType);
+
     UserBuilder setProfileProperties(Map<String, Object> profileProperties);
 
     UserBuilder putAllProfileProperties(Map<String, Object> profileProperties);

--- a/api/src/main/java/com/okta/sdk/resource/user/UserBuilder.java
+++ b/api/src/main/java/com/okta/sdk/resource/user/UserBuilder.java
@@ -53,6 +53,8 @@ public interface UserBuilder {
 
     UserBuilder setType(UserType userType);
 
+    UserBuilder setType(String userTypeId);
+
     UserBuilder setProfileProperties(Map<String, Object> profileProperties);
 
     UserBuilder putAllProfileProperties(Map<String, Object> profileProperties);

--- a/impl/src/main/java/com/okta/sdk/impl/resource/DefaultUserBuilder.java
+++ b/impl/src/main/java/com/okta/sdk/impl/resource/DefaultUserBuilder.java
@@ -48,6 +48,7 @@ public class DefaultUserBuilder implements UserBuilder {
     private Boolean active;
     private Boolean provider;
     private UserType userType;
+    private String userTypeId;
     private UserNextLogin nextLogin;
     private Set<String> groupIds = new HashSet<>();
     private Map<String, Object> passwordHashProperties;
@@ -115,6 +116,12 @@ public class DefaultUserBuilder implements UserBuilder {
         return this;
     }
 
+    @Override
+    public UserBuilder setType(String userTypeId) {
+        this.userTypeId = userTypeId;
+        return this;
+    }
+
     public UserBuilder setProfileProperties(Map<String, Object> profileProperties) {
 
         this.customProfileAttributes.clear();
@@ -164,6 +171,10 @@ public class DefaultUserBuilder implements UserBuilder {
         }
         else {
             userProfile.setLogin(email);
+        }
+
+        if (Strings.hasText(userTypeId)) {
+            user.setType(client.instantiate(UserType.class).setId(userTypeId));
         }
 
         if (userType != null) {

--- a/impl/src/main/java/com/okta/sdk/impl/resource/DefaultUserBuilder.java
+++ b/impl/src/main/java/com/okta/sdk/impl/resource/DefaultUserBuilder.java
@@ -15,7 +15,6 @@
  */
 package com.okta.sdk.impl.resource;
 
-
 import com.okta.sdk.client.Client;
 import com.okta.commons.lang.Collections;
 import com.okta.commons.lang.Strings;
@@ -26,6 +25,7 @@ import com.okta.sdk.resource.user.User;
 import com.okta.sdk.resource.user.UserCredentials;
 import com.okta.sdk.resource.user.UserNextLogin;
 import com.okta.sdk.resource.user.UserProfile;
+import com.okta.sdk.resource.user.UserType;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -35,7 +35,6 @@ import java.util.Map;
 import java.util.Set;
 
 public class DefaultUserBuilder implements UserBuilder {
-
 
     private char[] password;
     private String securityQuestion;
@@ -48,6 +47,7 @@ public class DefaultUserBuilder implements UserBuilder {
     private String mobilePhone;
     private Boolean active;
     private Boolean provider;
+    private UserType userType;
     private UserNextLogin nextLogin;
     private Set<String> groupIds = new HashSet<>();
     private Map<String, Object> passwordHashProperties;
@@ -106,6 +106,12 @@ public class DefaultUserBuilder implements UserBuilder {
 
     public UserBuilder setProvider(Boolean provider) {
         this.provider = provider;
+        return this;
+    }
+
+    @Override
+    public UserBuilder setType(UserType userType) {
+        this.userType = userType;
         return this;
     }
 

--- a/impl/src/main/java/com/okta/sdk/impl/resource/DefaultUserBuilder.java
+++ b/impl/src/main/java/com/okta/sdk/impl/resource/DefaultUserBuilder.java
@@ -176,8 +176,7 @@ public class DefaultUserBuilder implements UserBuilder {
         if (Strings.hasText(userTypeId)) {
             user.setType(client.instantiate(UserType.class).setId(userTypeId));
         }
-
-        if (userType != null) {
+        else if (userType != null) {
             user.setType(userType);
         }
 

--- a/impl/src/main/java/com/okta/sdk/impl/resource/DefaultUserBuilder.java
+++ b/impl/src/main/java/com/okta/sdk/impl/resource/DefaultUserBuilder.java
@@ -152,6 +152,7 @@ public class DefaultUserBuilder implements UserBuilder {
 
         User user = client.instantiate(User.class);
         user.setProfile(client.instantiate(UserProfile.class));
+        user.setType(userType);
         UserProfile userProfile = user.getProfile();
         if (Strings.hasText(firstName)) userProfile.setFirstName(firstName);
         if (Strings.hasText(lastName)) userProfile.setLastName(lastName);

--- a/impl/src/main/java/com/okta/sdk/impl/resource/DefaultUserBuilder.java
+++ b/impl/src/main/java/com/okta/sdk/impl/resource/DefaultUserBuilder.java
@@ -152,7 +152,6 @@ public class DefaultUserBuilder implements UserBuilder {
 
         User user = client.instantiate(User.class);
         user.setProfile(client.instantiate(UserProfile.class));
-        user.setType(userType);
         UserProfile userProfile = user.getProfile();
         if (Strings.hasText(firstName)) userProfile.setFirstName(firstName);
         if (Strings.hasText(lastName)) userProfile.setLastName(lastName);
@@ -165,6 +164,10 @@ public class DefaultUserBuilder implements UserBuilder {
         }
         else {
             userProfile.setLogin(email);
+        }
+
+        if (userType != null) {
+            user.setType(userType);
         }
 
         if (!Collections.isEmpty(groupIds)) {

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/UsersIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/UsersIT.groovy
@@ -48,6 +48,7 @@ import com.okta.sdk.tests.it.util.ITSupport
 import org.testng.Assert
 import org.testng.annotations.BeforeClass
 import org.testng.annotations.Test
+import wiremock.org.apache.commons.lang3.RandomStringUtils
 
 import java.time.Duration
 import java.nio.charset.StandardCharsets
@@ -186,12 +187,15 @@ class UsersIT extends ITSupport implements CrudTestSupport {
         def lastName = 'Activate'
         def email = "john-activate=${uniqueTestName}@example.com"
 
-        UserType userType = client.instantiate(UserType)
-            .setName(firstName + lastName)
-            .setDescription("Test User")
-            .setDisplayName(firstName + lastName)
+        // 1. Define a user type
+        String name = "java_sdk_user_type_" + RandomStringUtils.randomAlphanumeric(15)
 
-        // 1. Create a user
+        UserType userType = client.instantiate(UserType)
+            .setName(name)
+            .setDisplayName(name)
+            .setDescription(name + "_test_description")
+
+        // 2. Create a user with the above UserType
         User user = UserBuilder.instance()
                 .setEmail(email)
                 .setFirstName(firstName)
@@ -203,7 +207,7 @@ class UsersIT extends ITSupport implements CrudTestSupport {
         registerForCleanup(user)
         validateUser(user, firstName, lastName, email)
 
-        // 2. Assert user type
+        // 3. Assert user type
         assertThat(user.getType(), notNullValue())
 
         // 3. Activate the user and verify user in list of active users

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/UsersIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/UsersIT.groovy
@@ -206,7 +206,7 @@ class UsersIT extends ITSupport implements CrudTestSupport {
             .setPassword(password.toCharArray())
             .setActive(true)
         // See https://developer.okta.com/docs/reference/api/user-types/#specify-the-user-type-of-a-new-user
-            .setType(client.instantiate(UserType).setId(createdUserType.getId()))
+            .setType(createdUserType.getId())
             .buildAndCreate(client)
         registerForCleanup(user)
         validateUser(user, firstName, lastName, email)

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/UsersIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/UsersIT.groovy
@@ -42,6 +42,7 @@ import com.okta.sdk.resource.user.UserBuilder
 import com.okta.sdk.resource.user.UserCredentials
 import com.okta.sdk.resource.user.UserList
 import com.okta.sdk.resource.user.UserStatus
+import com.okta.sdk.resource.user.UserType
 import com.okta.sdk.tests.Scenario
 import com.okta.sdk.tests.it.util.ITSupport
 import org.testng.Assert
@@ -185,6 +186,11 @@ class UsersIT extends ITSupport implements CrudTestSupport {
         def lastName = 'Activate'
         def email = "john-activate=${uniqueTestName}@example.com"
 
+        UserType userType = client.instantiate(UserType)
+            .setName(firstName + lastName)
+            .setDescription("Test User")
+            .setDisplayName(firstName + lastName)
+
         // 1. Create a user
         User user = UserBuilder.instance()
                 .setEmail(email)
@@ -192,17 +198,18 @@ class UsersIT extends ITSupport implements CrudTestSupport {
                 .setLastName(lastName)
                 .setPassword(password.toCharArray())
                 .setActive(false)
+                .setType(userType)
                 .buildAndCreate(client)
         registerForCleanup(user)
         validateUser(user, firstName, lastName, email)
 
-        // 2. Activate the user and verify user in list of active users
+        // 2. Assert user type
+        assertThat(user.getType(), notNullValue())
+
+        // 3. Activate the user and verify user in list of active users
         user.activate(false)
         UserList users = client.listUsers(null, 'status eq \"ACTIVE\"', null, null, null)
         assertPresent(users, user)
-
-
-
     }
 
     @Test


### PR DESCRIPTION
<!-- 
Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
-->

<!--
Please help us process GitHub Issues faster by providing the following information.

Note: If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->

## Issue(s)
https://github.com/okta/okta-sdk-java/issues/431

## Description
Add setter for `UserType` property in `UserBuilder`.

## Category
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [ ] Bugfix
- [x] Enhancement
- [ ] New Feature
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit Test(s)
- [ ] Documentation
