### PR TITLE
okta-312949-add-debug-timestamp-create-delete-auth-server

### DIFF
--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/AuthorizationServerIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/AuthorizationServerIT.groovy
@@ -23,6 +23,8 @@ import com.okta.sdk.resource.policy.Policy
 import com.okta.sdk.resource.policy.PolicyRuleConditions
 import com.okta.sdk.resource.policy.PolicyType
 import com.okta.sdk.tests.it.util.ITSupport
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.testng.annotations.Test
 import wiremock.org.apache.commons.lang3.RandomStringUtils
 
@@ -41,17 +43,21 @@ import static com.okta.sdk.tests.it.util.Util.assertNotPresent
  */
 class AuthorizationServerIT extends ITSupport {
 
+    private Logger log = LoggerFactory.getLogger(AuthorizationServerIT)
+
     // Authorization server operations
 
     @Test
     void createAuthorizationServerTest() {
         String name = "java-sdk-it-" + UUID.randomUUID().toString()
 
+        log.debug("========= CREATE AUTHORIZATION SERVER ========= ")
         AuthorizationServer createdAuthorizationServer = client.createAuthorizationServer(
             client.instantiate(AuthorizationServer)
                 .setName(name)
                 .setDescription("Test Authorization Server")
                 .setAudiences(["api://example"]))
+        log.debug("========= REGISTER AUTHORIZATION SERVER " + createdAuthorizationServer.getId() + " FOR CLEANUP ========= ")
         registerForCleanup(createdAuthorizationServer)
 
         assertThat(createdAuthorizationServer, notNullValue())

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/util/ClientProvider.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/util/ClientProvider.groovy
@@ -198,7 +198,13 @@ trait ClientProvider implements IHookable {
                     if (deletable instanceof LinkedObject) {
                         deletable.setName(deletable.getPrimary().getName())
                     }
-                    deletable.delete()
+                    if (deletable instanceof AuthorizationServer) {
+                        log.debug("========= DELETE AUTHORIZATION SERVER ========= " + deletable.getId())
+                        deletable.delete()
+                    }
+                    else {
+                        deletable.delete()
+                    }
                 }
                 catch (Exception e) {
                     log.trace("Exception thrown during cleanup, it is ignored so the rest of the cleanup can be run:", e)


### PR DESCRIPTION
<!-- 
Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
-->

<!--
Please help us process GitHub Issues faster by providing the following information.

Note: If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->

## Issue(s)
[OKTA-312949](https://oktainc.atlassian.net/browse/OKTA-312949)

## Description
<!-- Add a brief description of the issue. -->

## Category
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [ ] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit Test(s)
- [ ] Documentation
