### PR TITLE
Added UserFactorProfile common parent interface for all individual UserFactor profile types

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.okta.sdk</groupId>
         <artifactId>okta-sdk-root</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-sdk-api</artifactId>

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.okta.sdk</groupId>
         <artifactId>okta-sdk-root</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-sdk-coverage</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.okta.sdk</groupId>
         <artifactId>okta-sdk-root</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-sdk-examples</artifactId>

--- a/examples/quickstart/pom.xml
+++ b/examples/quickstart/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.sdk</groupId>
         <artifactId>okta-sdk-examples</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/httpclients/httpclient/pom.xml
+++ b/httpclients/httpclient/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.okta.sdk</groupId>
         <artifactId>okta-sdk-root</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.1.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/httpclients/okhttp/pom.xml
+++ b/httpclients/okhttp/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.okta.sdk</groupId>
         <artifactId>okta-sdk-root</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.1.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.okta.sdk</groupId>
         <artifactId>okta-sdk-root</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-sdk-impl</artifactId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.sdk</groupId>
         <artifactId>okta-sdk-root</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>com.okta.sdk</groupId>
     <artifactId>okta-sdk-root</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Okta Java SDK</name>
@@ -72,27 +72,27 @@
             <dependency>
                 <groupId>com.okta.sdk</groupId>
                 <artifactId>okta-sdk-api</artifactId>
-                <version>2.0.1-SNAPSHOT</version>
+                <version>2.1.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.okta.sdk</groupId>
                 <artifactId>okta-sdk-impl</artifactId>
-                <version>2.0.1-SNAPSHOT</version>
+                <version>2.1.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.okta.sdk</groupId>
                 <artifactId>okta-api-swagger-templates</artifactId>
-                <version>2.0.1-SNAPSHOT</version>
+                <version>2.1.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.okta.sdk</groupId>
                 <artifactId>okta-sdk-httpclient</artifactId>
-                <version>2.0.1-SNAPSHOT</version>
+                <version>2.1.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.okta.sdk</groupId>
                 <artifactId>okta-sdk-okhttp</artifactId>
-                <version>2.0.1-SNAPSHOT</version>
+                <version>2.1.0-SNAPSHOT</version>
             </dependency>
 
             <!-- Other Okta Projects -->
@@ -131,14 +131,14 @@
             <dependency>
                 <groupId>com.okta.sdk</groupId>
                 <artifactId>okta-sdk-integration-tests</artifactId>
-                <version>2.0.1-SNAPSHOT</version>
+                <version>2.1.0-SNAPSHOT</version>
             </dependency>
 
             <!-- Examples -->
             <dependency>
                 <groupId>com.okta.sdk</groupId>
                 <artifactId>okta-sdk-examples-quickstart</artifactId>
-                <version>2.0.1-SNAPSHOT</version>
+                <version>2.1.0-SNAPSHOT</version>
             </dependency>
 
             <!-- Logging -->
@@ -315,7 +315,7 @@
                         <dependency>
                             <groupId>com.okta.sdk</groupId>
                             <artifactId>okta-api-swagger-templates</artifactId>
-                            <version>2.0.1-SNAPSHOT</version>
+                            <version>2.1.0-SNAPSHOT</version>
                         </dependency>
                     </dependencies>
                 </plugin>

--- a/src/swagger/api.yaml
+++ b/src/swagger/api.yaml
@@ -7656,6 +7656,7 @@ definitions:
         type: string
       phoneNumber:
         type: string
+    x-okta-parent: '#/definitions/UserFactorProfile'
     x-okta-tags:
       - UserFactor
   ChangePasswordRequest:
@@ -7755,6 +7756,7 @@ definitions:
     properties:
       email:
         type: string
+    x-okta-parent: '#/definitions/UserFactorProfile'
     x-okta-tags:
       - UserFactor
   EnabledStatus:
@@ -8309,6 +8311,7 @@ definitions:
     properties:
       credentialId:
         type: string
+    x-okta-parent: '#/definitions/UserFactorProfile'
     x-okta-tags:
       - UserFactor
   IdentityProvider:
@@ -10686,6 +10689,7 @@ definitions:
         type: string
       version:
         type: string
+    x-okta-parent: '#/definitions/UserFactorProfile'
     x-okta-tags:
       - UserFactor
   RecoveryQuestionCredential:
@@ -11029,6 +11033,7 @@ definitions:
         type: string
       questionText:
         type: string
+    x-okta-parent: '#/definitions/UserFactorProfile'
     x-okta-tags:
       - UserFactor
   Session:
@@ -11213,6 +11218,7 @@ definitions:
     properties:
       phoneNumber:
         type: string
+    x-okta-parent: '#/definitions/UserFactorProfile'
     x-okta-tags:
       - UserFactor
   SocialAuthToken:
@@ -11328,6 +11334,7 @@ definitions:
     properties:
       credentialId:
         type: string
+    x-okta-parent: '#/definitions/UserFactorProfile'
     x-okta-tags:
       - UserFactor
   TotpUserFactor:
@@ -11341,6 +11348,7 @@ definitions:
     properties:
       credentialId:
         type: string
+    x-okta-parent: '#/definitions/UserFactorProfile'
     x-okta-tags:
       - UserFactor
   TrustedOrigin:
@@ -11410,6 +11418,7 @@ definitions:
     properties:
       credentialId:
         type: string
+    x-okta-parent: '#/definitions/UserFactorProfile'
     x-okta-tags:
       - UserFactor
   User:
@@ -11818,6 +11827,10 @@ definitions:
         web: '#/definitions/WebUserFactor'
         webauthn: '#/definitions/WebAuthnUserFactor'
       propertyName: factorType
+  UserFactorProfile:
+    properties: {}
+    x-okta-tags:
+      - UserFactor
   UserIdentifierConditionEvaluatorPattern:
     properties:
       matchType:
@@ -12116,6 +12129,7 @@ definitions:
     properties:
       credentialId:
         type: string
+    x-okta-parent: '#/definitions/UserFactorProfile'
     x-okta-tags:
       - UserFactor
   WebAuthnUserFactor:
@@ -12131,6 +12145,7 @@ definitions:
         type: string
       authenticatorName:
         type: string
+    x-okta-parent: '#/definitions/UserFactorProfile'
     x-okta-tags:
       - UserFactor
   WsFederationApplication:

--- a/swagger-templates/pom.xml
+++ b/swagger-templates/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.okta.sdk</groupId>
         <artifactId>okta-sdk-root</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-api-swagger-templates</artifactId>


### PR DESCRIPTION
<!-- 
Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
-->

<!--
Please help us process GitHub Issues faster by providing the following information.

Note: If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->

## Issue(s)
<!-- Reference any existing issue(s) here. -->

## Description

Prior to the major release 2.0.0, we had FactorProfile interface as common parent for all individual profile types (call, email, sms, totp etc).

With the 2.0.0 update, we removed the FactorProfile interface.

With this PR, I am adding a functionally equivalent interface named UserFactorProfile (inline with Factor -> UserFactor name change in major rev) as the common parent for individual UserFactor profile types.

Also submitted this change to **Open API** spec project at https://github.com/okta/openapi/pull/255.

## Category
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [ ] Bugfix
- [x] Enhancement
- [ ] New Feature
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit Test(s)
- [ ] Documentation
