### PR TITLE
OKTA-264486: app grp assignment make body param optional

### DIFF
--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/ApplicationsIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/ApplicationsIT.groovy
@@ -350,8 +350,7 @@ class ApplicationsIT extends ITSupport {
         assertThat(client.getApplication(app.getId()).getStatus(), equalTo(Application.StatusEnum.ACTIVE))
     }
 
-    // disabled to do: https://github.com/okta/openapi/issues/107
-    @Test(enabled = false)
+    @Test
     void groupAssignmentWithNullBodyTest() {
 
         Application app = client.createApplication(client.instantiate(AutoLoginApplication)
@@ -374,7 +373,7 @@ class ApplicationsIT extends ITSupport {
         registerForCleanup(app)
         registerForCleanup(group)
 
-        ApplicationGroupAssignment groupAssignment = app.createApplicationGroupAssignment(group.getId(), null)
+        ApplicationGroupAssignment groupAssignment = app.createApplicationGroupAssignment(group.getId())
         assertThat(groupAssignment, notNullValue())
     }
 

--- a/src/swagger/api.yaml
+++ b/src/swagger/api.yaml
@@ -698,7 +698,6 @@ paths:
           type: string
         - in: body
           name: applicationGroupAssignment
-          required: true
           schema:
             $ref: '#/definitions/ApplicationGroupAssignment'
       produces:

--- a/swagger-templates/src/main/resources/OktaJavaImpl/apiMethodPutNoBody.mustache
+++ b/swagger-templates/src/main/resources/OktaJavaImpl/apiMethodPutNoBody.mustache
@@ -1,5 +1,5 @@
 {{!
-    Copyright 2017 Okta
+    Copyright 2020-Present Okta, Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/swagger-templates/src/main/resources/OktaJavaImpl/apiMethodPutNoBody.mustache
+++ b/swagger-templates/src/main/resources/OktaJavaImpl/apiMethodPutNoBody.mustache
@@ -14,15 +14,25 @@
     limitations under the License.
 }}
 
-        {{#returnType}}return {{/returnType}}getDataStore().create(
-            "{{{vendorExtensions.hrefFiltered}}}",
+        String href = "{{{vendorExtensions.hrefFiltered}}}";
 {{#vendorExtensions.bodyIsSelf}}
-            this,
+    getDataStore().save(href, this, null, queryArgs, headers);
+    {{#returnType}}
+        return this;
+    {{/returnType}}
 {{/vendorExtensions.bodyIsSelf}}
 {{^vendorExtensions.bodyIsSelf}}
-            new DefaultVoidResource(getDataStore()),
+    {{#bodyParam}}
+        {{^bodyParam.required}}
+        ApplicationGroupAssignment applicationGroupAssignment = new DefaultApplicationGroupAssignment(getDataStore());
+        {{/bodyParam.required}}
+        getDataStore().save(href, {{bodyParam.paramName}}, this, queryArgs, headers);
+        {{#returnType}}return {{/returnType}} {{bodyParam.paramName}};
+    {{/bodyParam}}
+    {{^bodyParam}}
+        getDataStore().save(href, new DefaultVoidResource(getDataStore()), this, queryArgs, headers);
+        {{#returnType}}
+        return this;
+        {{/returnType}}
+    {{/bodyParam}}
 {{/vendorExtensions.bodyIsSelf}}
-            null,
-            {{#returnType}}{{returnType}}.class,{{/returnType}}
-            queryArgs,
-            headers);

--- a/swagger-templates/src/main/resources/OktaJavaImpl/apiMethodPutNoBody.mustache
+++ b/swagger-templates/src/main/resources/OktaJavaImpl/apiMethodPutNoBody.mustache
@@ -1,0 +1,38 @@
+{{!
+    Copyright 2017 Okta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+}}
+
+        String href = "{{{vendorExtensions.hrefFiltered}}}";
+{{#vendorExtensions.bodyIsSelf}}
+        getDataStore().save(href, this, null, queryArgs, headers);
+  {{#returnType}}
+        return this;
+  {{/returnType}}
+{{/vendorExtensions.bodyIsSelf}}
+{{^vendorExtensions.bodyIsSelf}}
+  {{#bodyParam}}
+        {{^bodyParam.required}}
+        ApplicationGroupAssignment applicationGroupAssignment = new DefaultApplicationGroupAssignment(getDataStore());
+        {{/bodyParam.required}}
+        getDataStore().save(href, {{bodyParam.paramName}}, this, queryArgs, headers);
+        {{#returnType}}return {{/returnType}} {{bodyParam.paramName}};
+  {{/bodyParam}}
+  {{^bodyParam}}
+        getDataStore().save(href, new DefaultVoidResource(getDataStore()), this, queryArgs, headers);
+    {{#returnType}}
+        return this;
+    {{/returnType}}
+  {{/bodyParam}}
+{{/vendorExtensions.bodyIsSelf}}

--- a/swagger-templates/src/main/resources/OktaJavaImpl/apiMethodPutNoBody.mustache
+++ b/swagger-templates/src/main/resources/OktaJavaImpl/apiMethodPutNoBody.mustache
@@ -14,25 +14,15 @@
     limitations under the License.
 }}
 
-        String href = "{{{vendorExtensions.hrefFiltered}}}";
+        {{#returnType}}return {{/returnType}}getDataStore().create(
+            "{{{vendorExtensions.hrefFiltered}}}",
 {{#vendorExtensions.bodyIsSelf}}
-        getDataStore().save(href, this, null, queryArgs, headers);
-  {{#returnType}}
-        return this;
-  {{/returnType}}
+            this,
 {{/vendorExtensions.bodyIsSelf}}
 {{^vendorExtensions.bodyIsSelf}}
-  {{#bodyParam}}
-        {{^bodyParam.required}}
-        ApplicationGroupAssignment applicationGroupAssignment = new DefaultApplicationGroupAssignment(getDataStore());
-        {{/bodyParam.required}}
-        getDataStore().save(href, {{bodyParam.paramName}}, this, queryArgs, headers);
-        {{#returnType}}return {{/returnType}} {{bodyParam.paramName}};
-  {{/bodyParam}}
-  {{^bodyParam}}
-        getDataStore().save(href, new DefaultVoidResource(getDataStore()), this, queryArgs, headers);
-    {{#returnType}}
-        return this;
-    {{/returnType}}
-  {{/bodyParam}}
+            new DefaultVoidResource(getDataStore()),
 {{/vendorExtensions.bodyIsSelf}}
+            null,
+            {{#returnType}}{{returnType}}.class,{{/returnType}}
+            queryArgs,
+            headers);

--- a/swagger-templates/src/main/resources/OktaJavaImpl/modelImpl.mustache
+++ b/swagger-templates/src/main/resources/OktaJavaImpl/modelImpl.mustache
@@ -163,7 +163,12 @@ public class Default{{classname}} extends {{#parent}}{{.}}{{/parent}}{{^parent}}
 {{>apiMethodGet}}
 {{/vendorExtensions.isGet}}
 {{#vendorExtensions.isPut}}
-{{>apiMethodPut}}
+    {{#vendorExtensions.optionalBody}}
+        {{>apiMethodPutNoBody}}
+    {{/vendorExtensions.optionalBody}}
+    {{^vendorExtensions.optionalBody}}
+        {{>apiMethodPut}}
+    {{/vendorExtensions.optionalBody}}
 {{/vendorExtensions.isPut}}
 {{#vendorExtensions.isPost}}
     {{#vendorExtensions.optionalBody}}


### PR DESCRIPTION
<!-- 
Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
-->

<!--
Please help us process GitHub Issues faster by providing the following information.

Note: If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->

## Issue(s)

[OKTA-264486](https://oktainc.atlassian.net/browse/OKTA-264486)

## Description

Body param of `Assign group to Application` API must be marked optional in spec (to match with [documentation](https://developer.okta.com/docs/reference/api/apps/#assign-group-to-application)). 

This PR lists the swagger code generation template changes in accordance to the above requirement.

## Category
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [ ] Bugfix
- [x] Enhancement
- [ ] New Feature
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit Test(s)
- [ ] Documentation
