### PR TITLE
Corrected link to docs for creating a service app

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Hard-coding the Okta domain and API token works for quick tests, but for real pr
 
 Okta allows you to interact with Okta APIs using scoped OAuth 2.0 access tokens. Each access token enables the bearer to perform specific actions on specific Okta endpoints, with that ability controlled by which scopes the access token contains.
 
-This SDK supports this feature only for service-to-service applications. Check out [our guides](https://developer.okta.com/docs/guides/implement-oauth-for-okta/overview/) to learn more about how to register a new service application using a private and public key pair.
+This SDK supports this feature only for service-to-service applications. Check out [our guides](https://developer.okta.com/docs/guides/implement-oauth-for-okta-serviceapp/overview/) to learn more about how to register a new service application using a private and public key pair.
 
 When using this approach, you won't need an API Token because the SDK will request an access token for you. In order to use OAuth 2.0, construct a client instance by passing the following parameters:
 


### PR DESCRIPTION
OAuth 2.0 section mentions that you must use a service application with private/public key pair, but included link to dev docs for how to create other application types

<!-- 
Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
-->

<!--
Please help us process GitHub Issues faster by providing the following information.

Note: If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->

## Issue(s)
<!-- Reference any existing issue(s) here. -->

## Description
<!-- Add a brief description of the issue. -->

## Category
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [ ] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit Test(s)
- [x] Documentation
