### PR TITLE
Added support for creating a user ready to import password via inline…

### DIFF
--- a/api/src/main/java/com/okta/sdk/resource/user/UserBuilder.java
+++ b/api/src/main/java/com/okta/sdk/resource/user/UserBuilder.java
@@ -31,6 +31,10 @@ public interface UserBuilder {
 
     UserBuilder setPassword(char[] password);
 
+    UserBuilder usePasswordHookForImport();
+
+    UserBuilder usePasswordHookForImport(String type);
+
     UserBuilder setSecurityQuestion(String question);
 
     UserBuilder setSecurityQuestionAnswer(String answer);


### PR DESCRIPTION
… password hook

## Description
Expands on the `UserBuilder` to include creating a user in state that is ready to have their password imported via inline password hook.

## Category

- [ ] Bugfix
- [x] Enhancement
- [ ] New Feature
- [ ] Configuration Change
- [ ] Versioning Change
- [x] Unit Test(s)
- [ ] Documentation
