### PR TITLE
Reverts the parallel classes test run change

### DIFF
--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/ApplicationsIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/ApplicationsIT.groovy
@@ -415,7 +415,8 @@ class ApplicationsIT extends ITSupport {
         assertThat(app.listGroupAssignments().iterator().size(), equalTo(0))
     }
 
-    @Test
+    // Remove this groups tag after OKTA-337342 is resolved (Adding this tag disables the test in bacon PDV)
+    @Test (groups = "bacon")
     void associateUserWithApplication() {
 
         Client client = getClient()

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/IdpIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/IdpIT.groovy
@@ -346,7 +346,7 @@ class IdpIT extends ITSupport {
         assertNotPresent(client.listIdentityProviders(), createdIdp)
     }
 
-    // Remove this groups tag after https://oktainc.atlassian.net/browse/OKTA-329987 is resolved (Adding this tag disables the test in bacon PDV)
+    // Remove this groups tag after OKTA-329987 is resolved (Adding this tag disables the test in bacon PDV)
     @Test (groups = "bacon")
     void microsoftIdpTest() {
 

--- a/pom.xml
+++ b/pom.xml
@@ -265,9 +265,9 @@
                         <trimStackTrace>false</trimStackTrace>
                         <reuseForks>true</reuseForks>
 
-                        <forkCount>2C</forkCount>
+<!--                         <forkCount>2C</forkCount>
                         <parallel>classes</parallel>
-                        <threadCount>5</threadCount>
+                        <threadCount>5</threadCount> -->
 
                     </configuration>
                 </plugin>


### PR DESCRIPTION
<!-- 
Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
-->

<!--
Please help us process GitHub Issues faster by providing the following information.

Note: If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->

## Issue(s)
<!-- Reference any existing issue(s) here. -->

## Description
<!-- Add a brief description of the issue. -->

## Category
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [ ] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit Test(s)
- [ ] Documentation
