### PR TITLE
Allow PEM-content of private key to be passed directly

### DIFF
--- a/api/src/main/java/com/okta/sdk/client/ClientBuilder.java
+++ b/api/src/main/java/com/okta/sdk/client/ClientBuilder.java
@@ -208,6 +208,7 @@ public interface ClientBuilder {
     String DEFAULT_CLIENT_ID_PROPERTY_NAME = "okta.client.clientId";
     String DEFAULT_CLIENT_SCOPES_PROPERTY_NAME = "okta.client.scopes";
     String DEFAULT_CLIENT_PRIVATE_KEY_PROPERTY_NAME = "okta.client.privateKey";
+    String DEFAULT_CLIENT_PRIVATE_KEY_CONTENT_PROPERTY_NAME = "okta.client.privateKeyContent";
     String DEFAULT_CLIENT_REQUEST_TIMEOUT_PROPERTY_NAME = "okta.client.requestTimeout";
     String DEFAULT_CLIENT_RETRY_MAX_ATTEMPTS_PROPERTY_NAME = "okta.client.rateLimit.maxRetries";
     String DEFAULT_CLIENT_TESTING_DISABLE_HTTPS_CHECK_PROPERTY_NAME = "okta.testing.disableHttpsCheck";

--- a/api/src/main/java/com/okta/sdk/client/ClientBuilder.java
+++ b/api/src/main/java/com/okta/sdk/client/ClientBuilder.java
@@ -333,6 +333,19 @@ public interface ClientBuilder {
     ClientBuilder setPrivateKey(String privateKey);
 
     /**
+     * Allows passing of PEM payload for the private key directly, avoiding the
+     * need to access the filesystem directly.
+     *
+     * @see #setPrivateKey(String)
+     * @param privateKeyContent the full PEM-payload
+     * @return the ClientBuilder instance for method chaining.
+     *
+     * @throws IllegalArgumentException when {@link #setPrivateKey(String)} was called before. They are mutually exclusive
+     * @since 2.0.1
+     */
+    ClientBuilder setPrivateKeyContent(String privateKeyContent);
+
+    /**
      * Allows specifying the client ID instead of relying on the default location + override/fallback behavior defined
      * in the {@link ClientBuilder documentation above}.
      *

--- a/impl/src/main/java/com/okta/sdk/impl/client/DefaultClientBuilder.java
+++ b/impl/src/main/java/com/okta/sdk/impl/client/DefaultClientBuilder.java
@@ -80,6 +80,9 @@ import java.util.concurrent.TimeUnit;
  * <li>Programmatically</li>
  * </ul>
  *
+ * Please be aware that, in general, loading secrets (such as api-keys or PEM-content) from environment variables
+ * or system properties can lead to those secrets being leaked.
+ *
  * @since 0.5.0
  */
 public class DefaultClientBuilder implements ClientBuilder {
@@ -225,7 +228,11 @@ public class DefaultClientBuilder implements ClientBuilder {
         }
 
         if (Strings.hasText(props.get(DEFAULT_CLIENT_PRIVATE_KEY_PROPERTY_NAME))) {
-            clientConfig.setPrivateKey(props.get(DEFAULT_CLIENT_PRIVATE_KEY_PROPERTY_NAME));
+            this.setPrivateKey(props.get(DEFAULT_CLIENT_PRIVATE_KEY_PROPERTY_NAME));
+        }
+
+        if (Strings.hasText(props.get(DEFAULT_CLIENT_PRIVATE_KEY_CONTENT_PROPERTY_NAME))) {
+            this.setPrivateKeyContent(props.get(DEFAULT_CLIENT_PRIVATE_KEY_CONTENT_PROPERTY_NAME));
         }
 
         if (Strings.hasText(props.get(DEFAULT_CLIENT_REQUEST_TIMEOUT_PROPERTY_NAME))) {

--- a/impl/src/main/java/com/okta/sdk/impl/config/ClientConfiguration.java
+++ b/impl/src/main/java/com/okta/sdk/impl/config/ClientConfiguration.java
@@ -56,6 +56,7 @@ public class ClientConfiguration extends HttpClientConfiguration {
     private String clientId;
     private Set<String> scopes = new HashSet<>();
     private String privateKey;
+    private String privateKeyContent;
 
     public String getApiToken() {
         return apiToken;
@@ -127,6 +128,14 @@ public class ClientConfiguration extends HttpClientConfiguration {
 
     public void setPrivateKey(String privateKey) {
         this.privateKey = privateKey;
+    }
+
+    public String getPrivateKeyContent() {
+        return privateKeyContent;
+    }
+
+    public void setPrivateKeyContent(String privateKeyContent) {
+        this.privateKeyContent = privateKeyContent;
     }
 
     public boolean isCacheManagerEnabled() {

--- a/impl/src/test/groovy/com/okta/sdk/impl/client/DefaultClientBuilderTest.groovy
+++ b/impl/src/test/groovy/com/okta/sdk/impl/client/DefaultClientBuilderTest.groovy
@@ -245,6 +245,29 @@ class DefaultClientBuilderTest {
     }
 
     @Test
+    void testOauth2SetPrivateKeyAndSetPrivateKeyContentAreMutuallyExclusive() {
+        clearOktaEnvAndSysProps()
+        Util.expect(IllegalArgumentException) {
+            new DefaultClientBuilder(noDefaultYamlNoAppYamlResourceFactory())
+                .setOrgUrl("https://okta.example.com")
+                .setAuthorizationMode(AuthorizationMode.PRIVATE_KEY)
+                .setClientId("client12345")
+                .setScopes(new HashSet<>(Arrays.asList({"okta.apps.read"})))
+                .setPrivateKey("blahblah.pem")
+                .setPrivateKeyContent("foo")
+        }
+        Util.expect(IllegalArgumentException) {
+            new DefaultClientBuilder(noDefaultYamlNoAppYamlResourceFactory())
+                .setOrgUrl("https://okta.example.com")
+                .setAuthorizationMode(AuthorizationMode.PRIVATE_KEY)
+                .setClientId("client12345")
+                .setScopes(new HashSet<>(Arrays.asList({"okta.apps.read"})))
+                .setPrivateKeyContent("foo")
+                .setPrivateKey("blahblah.pem")
+        }
+    }
+
+    @Test
     void testOAuth2InvalidPrivateKeyPemFilePath() {
         clearOktaEnvAndSysProps()
         Util.expect(IllegalArgumentException) {

--- a/impl/src/test/groovy/com/okta/sdk/impl/client/DefaultClientBuilderTest.groovy
+++ b/impl/src/test/groovy/com/okta/sdk/impl/client/DefaultClientBuilderTest.groovy
@@ -245,6 +245,33 @@ class DefaultClientBuilderTest {
     }
 
     @Test
+    void testOAuth2NullPrivateKeyContentAndFileString() {
+        clearOktaEnvAndSysProps()
+        Util.expect(IllegalArgumentException) {
+            new DefaultClientBuilder(noDefaultYamlNoAppYamlResourceFactory())
+                .setOrgUrl("https://okta.example.com")
+                .setAuthorizationMode(AuthorizationMode.PRIVATE_KEY)
+                .setClientId("client12345")
+                .setScopes(new HashSet<>(Arrays.asList({"okta.apps.read"})))
+                .build()
+        }
+    }
+
+    @Test
+    void testOAuth2ValidPrivateKeyContent() {
+        clearOktaEnvAndSysProps()
+        Util.expect(IllegalArgumentException) {
+            new DefaultClientBuilder(noDefaultYamlNoAppYamlResourceFactory())
+                .setOrgUrl("https://okta.example.com")
+                .setAuthorizationMode(AuthorizationMode.PRIVATE_KEY)
+                .setClientId("client12345")
+                .setScopes(new HashSet<>(Arrays.asList({"okta.apps.read"})))
+                .setPrivateKeyContent("mypem")
+                .build()
+        }
+    }
+
+    @Test
     void testOauth2SetPrivateKeyAndSetPrivateKeyContentAreMutuallyExclusive() {
         clearOktaEnvAndSysProps()
         Util.expect(IllegalArgumentException) {

--- a/impl/src/test/groovy/com/okta/sdk/impl/oauth2/AccessTokenRetrieverServiceImplTest.groovy
+++ b/impl/src/test/groovy/com/okta/sdk/impl/oauth2/AccessTokenRetrieverServiceImplTest.groovy
@@ -77,8 +77,9 @@ class AccessTokenRetrieverServiceImplTest {
     void testParsePrivateKey() {
         PrivateKey generatedPrivateKey = generatePrivateKey("RSA", 2048)
         File privateKeyPemFile = writePrivateKeyToPemFile(generatedPrivateKey, "privateKey")
+        Reader reader = new BufferedReader(new FileReader(privateKeyPemFile))
 
-        PrivateKey parsedPrivateKey = getAccessTokenRetrieverServiceInstance().parsePrivateKey(privateKeyPemFile.path)
+        PrivateKey parsedPrivateKey = getAccessTokenRetrieverServiceInstance().parsePrivateKey(reader)
 
         privateKeyPemFile.deleteOnExit()
 


### PR DESCRIPTION
Avoids reading from filesystem which is problematic in cloud-native environments.

<!-- 
Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
-->

<!--
Please help us process GitHub Issues faster by providing the following information.

Note: If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->

## Issue(s)
Fixes #486 
## Description
<!-- Add a brief description of the issue. -->

## Category
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [ ] Bugfix
- [x] Enhancement
- [ ] New Feature
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit Test(s)
- [ ] Documentation
