### PR TITLE
fix gradle wrapper cve

### DIFF
--- a/src/owasp/owasp-suppression.xml
+++ b/src/owasp/owasp-suppression.xml
@@ -21,9 +21,10 @@
 
     <!-- invalid artifact detection / swagger uber jars-->
     <suppress>
-       <notes><![CDATA[file name: swagger-codegen-2.2.3.jar: gradle-wrapper.jar]]></notes>
-       <sha1>0f6f1fa2b59ae770ca14f975726bed8d6620ed9b</sha1>
-       <cve>CVE-2016-6199</cve>
+        <notes><![CDATA[file name: swagger-codegen-2.2.3.jar: gradle-wrapper.jar]]></notes>
+        <sha1>0f6f1fa2b59ae770ca14f975726bed8d6620ed9b</sha1>
+        <cve>CVE-2016-6199</cve>
+        <cve>CVE-2020-11979</cve>
     </suppress>
 
     <!-- build time dependency contains older version of gradle (which this project does NOT use) -->


### PR DESCRIPTION
<!-- 
Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
-->

<!--
Please help us process GitHub Issues faster by providing the following information.

Note: If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->

## Issue(s)
<!-- Reference any existing issue(s) here. -->

## Description

```
    [ERROR] Failed to execute goal org.owasp:dependency-check-maven:6.1.0:aggregate (default-cli) on project okta-sdk-root:
    [ERROR]
    [ERROR] One or more dependencies were identified with vulnerabilities:
    [ERROR]
    [ERROR] swagger-codegen-2.2.3.jar: gradle-wrapper.jar: CVE-2020-11979
    [ERROR]
    [ERROR] See the dependency-check report for more details.
```

## Category
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [ ] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit Test(s)
- [ ] Documentation
