### PR TITLE
Support MD5 password import

### DIFF
--- a/api/src/main/java/com/okta/sdk/resource/user/UserBuilder.java
+++ b/api/src/main/java/com/okta/sdk/resource/user/UserBuilder.java
@@ -84,5 +84,7 @@ public interface UserBuilder {
 
     UserBuilder setSha1PasswordHash(String value, String salt, String saltOrder);
 
+    UserBuilder setMd5PasswordHash(String value, String salt, String saltOrder);
+
     User buildAndCreate(Client client);
 }

--- a/impl/src/main/java/com/okta/sdk/impl/resource/DefaultUserBuilder.java
+++ b/impl/src/main/java/com/okta/sdk/impl/resource/DefaultUserBuilder.java
@@ -269,6 +269,10 @@ public class DefaultUserBuilder implements UserBuilder {
         return setShaPasswordHash("SHA-1", value, salt, saltOrder);
     }
 
+    public UserBuilder setMd5PasswordHash(String value, String salt, String saltOrder) {
+        return setShaPasswordHash("MD5", value, salt, saltOrder);
+    }
+
     private UserBuilder setShaPasswordHash(String shaAlgorithm, String value, String salt, String saltOrder) {
         passwordHashProperties = new HashMap<>();
         passwordHashProperties.put("algorithm", shaAlgorithm);

--- a/impl/src/main/java/com/okta/sdk/impl/resource/DefaultUserBuilder.java
+++ b/impl/src/main/java/com/okta/sdk/impl/resource/DefaultUserBuilder.java
@@ -258,22 +258,22 @@ public class DefaultUserBuilder implements UserBuilder {
     }
 
     public UserBuilder setSha256PasswordHash(String value, String salt, String saltOrder) {
-        return setShaPasswordHash("SHA-256", value, salt, saltOrder);
+        return setPasswordHash("SHA-256", value, salt, saltOrder);
     }
 
     public UserBuilder setSha512PasswordHash(String value, String salt, String saltOrder) {
-        return setShaPasswordHash("SHA-512", value, salt, saltOrder);
+        return setPasswordHash("SHA-512", value, salt, saltOrder);
     }
 
     public UserBuilder setSha1PasswordHash(String value, String salt, String saltOrder) {
-        return setShaPasswordHash("SHA-1", value, salt, saltOrder);
+        return setPasswordHash("SHA-1", value, salt, saltOrder);
     }
 
     public UserBuilder setMd5PasswordHash(String value, String salt, String saltOrder) {
-        return setShaPasswordHash("MD5", value, salt, saltOrder);
+        return setPasswordHash("MD5", value, salt, saltOrder);
     }
 
-    private UserBuilder setShaPasswordHash(String shaAlgorithm, String value, String salt, String saltOrder) {
+    private UserBuilder setPasswordHash(String shaAlgorithm, String value, String salt, String saltOrder) {
         passwordHashProperties = new HashMap<>();
         passwordHashProperties.put("algorithm", shaAlgorithm);
         passwordHashProperties.put("salt", salt);

--- a/impl/src/test/groovy/com/okta/sdk/impl/resource/DefaultUserBuilderTest.groovy
+++ b/impl/src/test/groovy/com/okta/sdk/impl/resource/DefaultUserBuilderTest.groovy
@@ -209,6 +209,43 @@ class DefaultUserBuilderTest {
     }
 
     @Test
+    void importPasswordMd5() {
+        def client = mock(Client)
+        def user = mock(User)
+        def profile = mock(UserProfile)
+        def passwordCredential = mock(PasswordCredential)
+        def userCredentials = mock(UserCredentials)
+        when(client.instantiate(User)).thenReturn(user)
+        when(client.instantiate(UserProfile)).thenReturn(profile)
+        when(client.instantiate(UserCredentials)).thenReturn(userCredentials)
+        when(client.instantiate(PasswordCredential)).thenReturn(passwordCredential)
+        when(user.getProfile()).thenReturn(profile)
+        when(user.getCredentials()).thenReturn(userCredentials)
+
+        String salt = "some-salt"
+        String hashedPassword = "a-hashed-password"
+
+        new DefaultUserBuilder()
+            .setFirstName("Joe")
+            .setLastName("Coder")
+            .setEmail("joe.coder@example.com")
+            .setMd5PasswordHash(hashedPassword, salt, "PREFIX")
+            .buildAndCreate(client)
+
+        def hashCapture = ArgumentCaptor.forClass(Map.class)
+
+        verify(userCredentials).setPassword(passwordCredential)
+        verify(passwordCredential).put(eq("hash"), hashCapture.capture())
+
+        assertThat hashCapture.value, allOf(
+            hasEntry("salt", salt),
+            hasEntry("saltOrder", "PREFIX"),
+            hasEntry("value", hashedPassword),
+            hasEntry("algorithm", "MD5"),
+            aMapWithSize(4))
+    }
+
+    @Test
     void createUserWithClearAndImportPassword() {
 
         def client = mock(Client)

--- a/impl/src/test/groovy/com/okta/sdk/impl/resource/DefaultUserBuilderTest.groovy
+++ b/impl/src/test/groovy/com/okta/sdk/impl/resource/DefaultUserBuilderTest.groovy
@@ -211,16 +211,16 @@ class DefaultUserBuilderTest {
     @Test
     void importPasswordMd5() {
         def client = mock(Client)
-        def user = mock(User)
+        def createUserRequest = mock(CreateUserRequest)
         def profile = mock(UserProfile)
         def passwordCredential = mock(PasswordCredential)
         def userCredentials = mock(UserCredentials)
-        when(client.instantiate(User)).thenReturn(user)
+        when(client.instantiate(CreateUserRequest)).thenReturn(createUserRequest)
         when(client.instantiate(UserProfile)).thenReturn(profile)
         when(client.instantiate(UserCredentials)).thenReturn(userCredentials)
         when(client.instantiate(PasswordCredential)).thenReturn(passwordCredential)
-        when(user.getProfile()).thenReturn(profile)
-        when(user.getCredentials()).thenReturn(userCredentials)
+        when(createUserRequest.getProfile()).thenReturn(profile)
+        when(createUserRequest.getCredentials()).thenReturn(userCredentials)
 
         String salt = "some-salt"
         String hashedPassword = "a-hashed-password"

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/UsersIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/UsersIT.groovy
@@ -761,6 +761,22 @@ class UsersIT extends ITSupport implements CrudTestSupport {
         assertThat user.getCredentials().getProvider().getType(), is(AuthenticationProviderType.IMPORT)
     }
 
+    @Test
+    void importUserWithMd5Password() {
+        def salt = "aSalt"
+
+        User user = UserBuilder.instance()
+                .setEmail("joe.coder+${uniqueTestName}@example.com")
+                .setFirstName("Joe")
+                .setLastName("Code")
+                .setMd5PasswordHash(hashPassword("aPassword", salt), salt, "PREFIX")
+                .buildAndCreate(getClient())
+        registerForCleanup(user)
+
+        assertThat user.getCredentials(), notNullValue()
+        assertThat user.getCredentials().getProvider().getType(), is(AuthenticationProviderType.IMPORT)
+    }
+
     private void ensureCustomProperties() {
         def userSchemaUri = "/api/v1/meta/schemas/user/default"
 

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/UsersIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/UsersIT.groovy
@@ -48,7 +48,6 @@ import com.okta.sdk.tests.Scenario
 import com.okta.sdk.tests.it.util.ITSupport
 import org.testng.Assert
 import org.testng.annotations.BeforeClass
-import org.testng.annotations.Ignore
 import org.testng.annotations.Test
 import wiremock.org.apache.commons.lang3.RandomStringUtils
 
@@ -779,8 +778,7 @@ class UsersIT extends ITSupport implements CrudTestSupport {
         assertThat user.getCredentials().getProvider().getType(), is(AuthenticationProviderType.IMPORT)
     }
 
-    @Test
-    @Ignore     // TODO: fix this when the OKTA-379446 is resolved
+    @Test(enabled = false)      // TODO: Enable it back when 379446 is resolved.
     void importCreateAndLoginUserWithMd5Password() {
         def salt = "aSalt"
         def password = "aPassword"

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/UsersIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/UsersIT.groovy
@@ -34,6 +34,7 @@ import com.okta.sdk.resource.role.RoleType
 import com.okta.sdk.resource.user.AuthenticationProviderType
 import com.okta.sdk.resource.user.ChangePasswordRequest
 import com.okta.sdk.resource.user.PasswordCredential
+import com.okta.sdk.resource.user.PasswordCredentialHashAlgorithm
 import com.okta.sdk.resource.user.RecoveryQuestionCredential
 import com.okta.sdk.resource.user.ResetPasswordToken
 import com.okta.sdk.resource.user.Role
@@ -47,6 +48,7 @@ import com.okta.sdk.tests.Scenario
 import com.okta.sdk.tests.it.util.ITSupport
 import org.testng.Assert
 import org.testng.annotations.BeforeClass
+import org.testng.annotations.Ignore
 import org.testng.annotations.Test
 import wiremock.org.apache.commons.lang3.RandomStringUtils
 
@@ -746,7 +748,7 @@ class UsersIT extends ITSupport implements CrudTestSupport {
     void importUserWithSha512Password() {
 
         def salt = "aSalt"
-        def hashedPassword = hashPassword("aPassword", salt)
+        def hashedPassword = hashPassword("aPassword", salt, PasswordCredentialHashAlgorithm.SHA_512)
 
         def email = "joe.coder+${uniqueTestName}@example.com"
         User user = UserBuilder.instance()
@@ -769,12 +771,48 @@ class UsersIT extends ITSupport implements CrudTestSupport {
                 .setEmail("joe.coder+${uniqueTestName}@example.com")
                 .setFirstName("Joe")
                 .setLastName("Code")
-                .setMd5PasswordHash(hashPassword("aPassword", salt), salt, "PREFIX")
+                .setMd5PasswordHash(hashPassword("aPassword", salt, PasswordCredentialHashAlgorithm.MD5), salt, "PREFIX")
                 .buildAndCreate(getClient())
         registerForCleanup(user)
 
         assertThat user.getCredentials(), notNullValue()
         assertThat user.getCredentials().getProvider().getType(), is(AuthenticationProviderType.IMPORT)
+    }
+
+    @Test
+    @Ignore     // TODO: fix this when the OKTA-379446 is resolved
+    void importCreateAndLoginUserWithMd5Password() {
+        def salt = "aSalt"
+        def password = "aPassword"
+        def hashPassword = hashPassword(password, salt, PasswordCredentialHashAlgorithm.MD5)
+        def login = "joe.coder+${uniqueTestName}@example.com"
+        def client = getClient()
+
+        User user = UserBuilder.instance()
+            .setEmail(login)
+            .setFirstName("Joe")
+            .setLastName("Code")
+            .setMd5PasswordHash(hashPassword, salt, "PREFIX")
+            .buildAndCreate(client)
+        registerForCleanup(user)
+
+        URL url = new URL(new URL(new URL(user.getResourceHref()), "/").toString() + "api/v1/authn")
+        HttpURLConnection con = (HttpURLConnection) url.openConnection()
+        con.setRequestMethod("POST")
+        con.setRequestProperty("Content-Type", "application/json; utf-8")
+        con.setRequestProperty("Accept", "application/json")
+        con.setDoOutput(true)
+        byte[] input = "{\"password\":\"${password}\",\"username\":\"${login}\"}".getBytes("utf-8")
+        con.getOutputStream().write(input, 0, input.length)
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(con.getInputStream(), "utf-8"))
+        StringBuilder response = new StringBuilder()
+        String responseLine
+        while ((responseLine = br.readLine()) != null) {
+            response.append(responseLine.trim())
+        }
+
+        assertThat response.toString().contains("\"status\":\"SUCCESS\""), is(true)
     }
 
     private void ensureCustomProperties() {
@@ -809,8 +847,8 @@ class UsersIT extends ITSupport implements CrudTestSupport {
         return addProperty
     }
 
-    private String hashPassword(String password, String salt) {
-        def messageDigest = MessageDigest.getInstance("SHA-512")
+    private static String hashPassword(String password, String salt, PasswordCredentialHashAlgorithm algorithm) {
+        def messageDigest = MessageDigest.getInstance(algorithm.toString())
         messageDigest.update(salt.getBytes(StandardCharsets.UTF_8))
         def bytes = messageDigest.digest(password.getBytes(StandardCharsets.UTF_8))
         return Base64.getEncoder().encodeToString(bytes)


### PR DESCRIPTION
## Issue(s)
[OKTA-345073](https://oktainc.atlassian.net/browse/OKTA-345073)

## Description
Java supports importing passwords during user creation, but missed supporting MD5.
https://developer.okta.com/docs/reference/api/users/?_ga=2.256403149.798616206.1604938188-1845868290.1601670746#md5-hashed-password-object-example
This is an SDK update to import MD5 passwords.

## Category
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [ ] Bugfix
- [x] Enhancement
- [ ] New Feature
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit Test(s)
- [ ] Documentation
