### PR TITLE
Java Mgmt SDK - Incorrect method param type in UserBuilder::setProvider()

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -319,6 +319,17 @@ Below methods have been added.
 - `ForgotPasswordResponse forgotPasswordSetNewPassword(UserCredentials userCredentials, Boolean sendEmail)`
 - `ForgotPasswordResponse forgotPasswordSetNewPassword(UserCredentials userCredentials)`
 
+### Package `com.okta.sdk.resource.user.UserBuilder`
+
+Below method has undergone a signature change.
+- `UserBuilder setProvider(Boolean provider)` signature changed to `UserBuilder setProvider(AuthenticationProvider provider)`
+
+### Package `com.okta.sdk.resource.impl.DefaultUserBuilder`
+
+Below method has undergone a signature change.
+- `UserBuilder setProvider(Boolean provider)` signature changed to `UserBuilder setProvider(AuthenticationProvider provider)`
+
+
 ## Migrating from 2.x.x to 3.0.0
 
 Version 3.0.0 of this SDK introduces a number of breaking changes from previous versions. 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -324,12 +324,6 @@ Below methods have been added.
 Below method has undergone a signature change.
 - `UserBuilder setProvider(Boolean provider)` signature changed to `UserBuilder setProvider(AuthenticationProvider provider)`
 
-### Package `com.okta.sdk.resource.impl.DefaultUserBuilder`
-
-Below method has undergone a signature change.
-- `UserBuilder setProvider(Boolean provider)` signature changed to `UserBuilder setProvider(AuthenticationProvider provider)`
-
-
 ## Migrating from 2.x.x to 3.0.0
 
 Version 3.0.0 of this SDK introduces a number of breaking changes from previous versions. 

--- a/api/src/main/java/com/okta/sdk/resource/user/UserBuilder.java
+++ b/api/src/main/java/com/okta/sdk/resource/user/UserBuilder.java
@@ -54,7 +54,7 @@ public interface UserBuilder {
 
     UserBuilder setActive(Boolean active);
 
-    UserBuilder setProvider(Boolean provider);
+    UserBuilder setProvider(AuthenticationProvider provider);
 
     UserBuilder setType(UserType userType);
 

--- a/impl/src/main/java/com/okta/sdk/impl/resource/DefaultUserBuilder.java
+++ b/impl/src/main/java/com/okta/sdk/impl/resource/DefaultUserBuilder.java
@@ -18,6 +18,7 @@ package com.okta.sdk.impl.resource;
 import com.okta.sdk.client.Client;
 import com.okta.commons.lang.Collections;
 import com.okta.commons.lang.Strings;
+import com.okta.sdk.resource.user.AuthenticationProvider;
 import com.okta.sdk.resource.user.PasswordCredentialHook;
 import com.okta.sdk.resource.user.RecoveryQuestionCredential;
 import com.okta.sdk.resource.user.UserBuilder;
@@ -48,7 +49,7 @@ public class DefaultUserBuilder implements UserBuilder {
     private String lastName;
     private String mobilePhone;
     private Boolean active;
-    private Boolean provider;
+    private AuthenticationProvider provider;
     private UserType userType;
     private String userTypeId;
     private UserNextLogin nextLogin;
@@ -117,7 +118,7 @@ public class DefaultUserBuilder implements UserBuilder {
         return this;
     }
 
-    public UserBuilder setProvider(Boolean provider) {
+    public UserBuilder setProvider(AuthenticationProvider provider) {
         this.provider = provider;
         return this;
     }
@@ -210,6 +211,11 @@ public class DefaultUserBuilder implements UserBuilder {
             createCredentialsIfNeeded(createUserRequest, client).setRecoveryQuestion(question);
         }
 
+        // authentication provider
+        if (provider != null) {
+            createCredentialsIfNeeded(createUserRequest, client).setProvider(provider);
+        }
+
         // user password
         if (password != null && password.length > 0) {
 
@@ -280,6 +286,6 @@ public class DefaultUserBuilder implements UserBuilder {
 
     @Override
     public User buildAndCreate(Client client) {
-        return client.createUser(build(client), active, provider, nextLogin);
+        return client.createUser(build(client), active, provider != null, nextLogin);
     }
 }

--- a/impl/src/test/groovy/com/okta/sdk/impl/resource/DefaultUserBuilderTest.groovy
+++ b/impl/src/test/groovy/com/okta/sdk/impl/resource/DefaultUserBuilderTest.groovy
@@ -54,7 +54,7 @@ class DefaultUserBuilderTest {
             .setNextLogin(UserNextLogin.CHANGEPASSWORD)
             .buildAndCreate(client)
 
-        verify(client).createUser(eq(createUserRequest), eq(null), eq(null), eq(UserNextLogin.CHANGEPASSWORD))
+        verify(client).createUser(eq(createUserRequest), eq(null), eq(false), eq(UserNextLogin.CHANGEPASSWORD))
         verify(profile).setFirstName("Joe")
         verify(profile).setLastName("Coder")
         verify(profile).setEmail("joe.coder@example.com")

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/UsersIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/UsersIT.groovy
@@ -31,6 +31,7 @@ import com.okta.sdk.resource.policy.PasswordPolicySettings
 import com.okta.sdk.resource.policy.PolicyNetworkCondition
 import com.okta.sdk.resource.role.AssignRoleRequest
 import com.okta.sdk.resource.role.RoleType
+import com.okta.sdk.resource.user.AuthenticationProvider
 import com.okta.sdk.resource.user.AuthenticationProviderType
 import com.okta.sdk.resource.user.ChangePasswordRequest
 import com.okta.sdk.resource.user.ForgotPasswordResponse
@@ -821,6 +822,33 @@ class UsersIT extends ITSupport implements CrudTestSupport {
         assertThat response.get("recovery_question")["question"], equalTo("How many roads must a man walk down?")
         assertThat response.get("provider")["type"], equalTo("OKTA")
         assertThat response.get("provider")["name"], equalTo("OKTA")
+    }
+
+    @Test
+    void userWithAuthenticationProviderTest() {
+
+        def firstName = 'John'
+        def lastName = 'Forgot-Password'
+        def email = "john-${uniqueTestName}@example.com"
+
+        def authenticationProvider = client.instantiate(AuthenticationProvider)
+        authenticationProvider.setName(AuthenticationProviderType.FEDERATION.toString())
+        authenticationProvider.setType(AuthenticationProviderType.FEDERATION)
+
+        // 1. Create a user
+        User user = UserBuilder.instance()
+            .setEmail(email)
+            .setFirstName(firstName)
+            .setLastName(lastName)
+            .setLogin(email)
+            .setProvider(authenticationProvider)
+            .buildAndCreate(client)
+        registerForCleanup(user)
+        validateUser(user, firstName, lastName, email)
+
+        assertThat user.getCredentials(), notNullValue()
+        assertThat user.getCredentials().getProvider().getType(), is(AuthenticationProviderType.FEDERATION)
+        assertThat user.getCredentials().getProvider().getName(), equalTo(AuthenticationProviderType.FEDERATION.toString())
     }
 
     private void ensureCustomProperties() {

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/UsersIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/UsersIT.groovy
@@ -832,8 +832,8 @@ class UsersIT extends ITSupport implements CrudTestSupport {
         def email = "john-${uniqueTestName}@example.com"
 
         def authenticationProvider = client.instantiate(AuthenticationProvider)
-        authenticationProvider.setName(AuthenticationProviderType.FEDERATION.toString())
-        authenticationProvider.setType(AuthenticationProviderType.FEDERATION)
+            .setName(AuthenticationProviderType.FEDERATION.name())
+            .setType(AuthenticationProviderType.FEDERATION)
 
         // 1. Create a user
         User user = UserBuilder.instance()
@@ -848,7 +848,7 @@ class UsersIT extends ITSupport implements CrudTestSupport {
 
         assertThat user.getCredentials(), notNullValue()
         assertThat user.getCredentials().getProvider().getType(), is(AuthenticationProviderType.FEDERATION)
-        assertThat user.getCredentials().getProvider().getName(), equalTo(AuthenticationProviderType.FEDERATION.toString())
+        assertThat user.getCredentials().getProvider().getName(), equalTo(AuthenticationProviderType.FEDERATION.name())
     }
 
     private void ensureCustomProperties() {


### PR DESCRIPTION
## Issue:

OKTA-381889

## Description
`UserBuilder` method `setProvider` must accept [AuthenticationProvider](https://github.com/okta/okta-management-openapi-spec/blob/master/resources/spec.yaml#L7799) instead of a boolean. 

[Create User with Authentication Provider](https://developer.okta.com/docs/reference/api/users/#create-user-with-authentication-provider)

## Category
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [x] Bugfix
- [x] Unit Test(s)
- [x] Documentation
