### PR TITLE
OKTA-382495: Java Mgmt SDK - Add getNextPageUrl() helper for Pagination

### DIFF
--- a/api/src/main/java/com/okta/sdk/resource/CollectionResource.java
+++ b/api/src/main/java/com/okta/sdk/resource/CollectionResource.java
@@ -46,4 +46,10 @@ public interface CollectionResource<T extends Resource> extends Resource, Iterab
      */
     Stream<T> stream();
 
+    /**
+     * Returns a next page URL
+     *
+     * @return a URL link to the next resource, or {@code null} if the current resource is the last one.
+     */
+    String getNextPageUrl();
 }

--- a/impl/src/main/java/com/okta/sdk/impl/resource/AbstractCollectionResource.java
+++ b/impl/src/main/java/com/okta/sdk/impl/resource/AbstractCollectionResource.java
@@ -67,12 +67,13 @@ public abstract class AbstractCollectionResource<T extends Resource> extends Abs
         }
     }
 
-    private String getNextPageHref() {
+    @Override
+    public String getNextPageUrl() {
         return nextPageHref;
     }
 
     private boolean hasNextPage() {
-        return getNextPageHref() != null;
+        return getNextPageUrl() != null;
     }
 
     @Override
@@ -206,7 +207,7 @@ public abstract class AbstractCollectionResource<T extends Resource> extends Abs
                 //only represents a single page.
 
                 AbstractCollectionResource nextResource =
-                        getDataStore().getResource(getNextPageHref(), resource.getClass());
+                        getDataStore().getResource(getNextPageUrl(), resource.getClass());
                 Page<T> nextPage = nextResource.getCurrentPage();
                 Iterator<T> nextIterator = nextPage.getItems().iterator();
 

--- a/impl/src/test/groovy/com/okta/sdk/impl/resource/AbstractCollectionResourceTest.groovy
+++ b/impl/src/test/groovy/com/okta/sdk/impl/resource/AbstractCollectionResourceTest.groovy
@@ -38,12 +38,13 @@ class AbstractCollectionResourceTest {
         def page2 = createTestPage(200, 200, "https://example.com/resource?nextPage=2")
         def page3 = createTestPage(400, 13, null)
 
+        def collectionResource1 = new TestCollectionResource(ds, page1)
         expectPage(page1, ds)
         def collectionResource2 = new TestCollectionResource(ds, page2)
-        when(ds.getResource("https://example.com/resource?nextPage=1", TestCollectionResource)).thenReturn(collectionResource2)
+        when(ds.getResource(collectionResource1.getNextPageUrl(), TestCollectionResource)).thenReturn(collectionResource2)
         expectPage(page2, ds)
         def collectionResource3 = new TestCollectionResource(ds, page3)
-        when(ds.getResource("https://example.com/resource?nextPage=2", TestCollectionResource)).thenReturn(collectionResource3)
+        when(ds.getResource(collectionResource2.getNextPageUrl(), TestCollectionResource)).thenReturn(collectionResource3)
         expectPage(page3, ds)
 
         verifyCollection(new TestCollectionResource(ds, page1), 413)

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/UsersIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/UsersIT.groovy
@@ -851,6 +851,31 @@ class UsersIT extends ITSupport implements CrudTestSupport {
         assertThat user.getCredentials().getProvider().getName(), equalTo(AuthenticationProviderType.FEDERATION.name())
     }
 
+    @Test
+    void testGetNextPageUrl() {
+        def user1 = create(client)
+        def user2 = create(client)
+        def user3 = create(client)
+        registerForCleanup(user1)
+        registerForCleanup(user2)
+        registerForCleanup(user3)
+
+        String pageSize = "2"
+
+        def userListFirstPage = client.http()
+            .addQueryParameter("limit", pageSize)
+            .get("/api/v1/users", UserList.class)
+        assertThat userListFirstPage, notNullValue()
+        assertThat userListFirstPage.getNextPageUrl(), notNullValue()
+        assertThat userListFirstPage.getProperties().get("currentPage").getProperties().get("items").collect().size(), is(2)
+
+        def userListSecondPage = client.http()
+            .addQueryParameter("limit", pageSize)
+            .get(userListFirstPage.getNextPageUrl(), UserList.class)
+        assertThat userListSecondPage, notNullValue()
+        assertThat userListSecondPage.getProperties().get("currentPage").getProperties().get("items").collect().size(), is(greaterThanOrEqualTo(1))
+    }
+
     private void ensureCustomProperties() {
         def userSchemaUri = "/api/v1/meta/schemas/user/default"
 


### PR DESCRIPTION
## Issue(s)
https://github.com/okta/okta-sdk-java/issues/562

## Description
Expose a method getNextPageUrl() in CollectionResource class to help the user get to the next page for Pagination use cases.

## Category
- [x] New Feature
