### PR TITLE
OKTA-386854: Enable option to supply kid as part of ClientBuilder interface

### DIFF
--- a/api/src/main/java/com/okta/sdk/client/ClientBuilder.java
+++ b/api/src/main/java/com/okta/sdk/client/ClientBuilder.java
@@ -422,6 +422,14 @@ public interface ClientBuilder {
     ClientBuilder setRetryMaxAttempts(int maxAttempts);
 
     /**
+     * Sets Key ID.
+     *
+     * @param kid unique identifier for the key
+     * @return the ClientBuilder instance for method chaining
+     */
+    ClientBuilder setKid(String kid);
+
+    /**
      * Constructs a new {@link Client} instance based on the ClientBuilder's current configuration state.
      *
      * @return a new {@link Client} instance based on the ClientBuilder's current configuration state.

--- a/impl/src/main/java/com/okta/sdk/impl/client/DefaultClientBuilder.java
+++ b/impl/src/main/java/com/okta/sdk/impl/client/DefaultClientBuilder.java
@@ -330,6 +330,12 @@ public class DefaultClientBuilder implements ClientBuilder {
     }
 
     @Override
+    public ClientBuilder setKid(String kid) {
+        this.clientConfig.setKid(kid);
+        return this;
+    }
+
+    @Override
     public Client build() {
         if (!this.clientConfig.isCacheManagerEnabled()) {
             log.debug("CacheManager disabled. Defaulting to DisabledCacheManager");

--- a/impl/src/test/groovy/com/okta/sdk/impl/client/DefaultClientBuilderTest.groovy
+++ b/impl/src/test/groovy/com/okta/sdk/impl/client/DefaultClientBuilderTest.groovy
@@ -496,6 +496,14 @@ class DefaultClientBuilderTest {
         assertThat clientBuilder.clientConfiguration.getKid(), is("kid-value")
     }
 
+    @Test
+    void testSetterKid() {
+        clearOktaEnvAndSysProps()
+        System.setProperty("okta.client.kid", "kid-value")
+        DefaultClientBuilder clientBuilder = (DefaultClientBuilder) Clients.builder().setKid("another-kid-value")
+        assertThat clientBuilder.clientConfiguration.getKid(), is("another-kid-value")
+    }
+
     // helper methods
 
     static generatePrivateKey(String algorithm, int keySize, String fileNamePrefix, String fileNameSuffix) {


### PR DESCRIPTION
## Issue(s)
https://github.com/okta/okta-sdk-java/issues/576

## Description
Enable option to support Key ID (kid) as part of ClientBuilder interface.

## Category
- [ ] Bugfix
- [ ] Enhancement
- [x] New Feature
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit Test(s)
- [ ] Documentation
