### PR TITLE
OKTA-385628: Enable option to supply RequestExecutorFactory via ClientBuilder interface

### DIFF
--- a/api/src/main/java/com/okta/sdk/client/ClientBuilder.java
+++ b/api/src/main/java/com/okta/sdk/client/ClientBuilder.java
@@ -435,8 +435,6 @@ public interface ClientBuilder {
     /**
      * Sets the {@link RequestExecutorFactory},
      * otherwise it will be loaded as a Service / SPI via the {@link RequestExecutorFactory} class
-     * <p>
-     * {@link com.okta.sdk.impl.client.BaseClient#createRequestExecutor}
      *
      * @param requestExecutorFactory that should be used to create the RequestExecutor
      * @return the ClientBuilder instance for method chaining

--- a/api/src/main/java/com/okta/sdk/client/ClientBuilder.java
+++ b/api/src/main/java/com/okta/sdk/client/ClientBuilder.java
@@ -433,7 +433,9 @@ public interface ClientBuilder {
     ClientBuilder setRetryMaxAttempts(int maxAttempts);
 
     /**
-     * Sets the {@link RequestExecutorFactory}, otherwise the one will be used from the classpath.
+     * Sets the {@link RequestExecutorFactory},
+     * otherwise it will be loaded as a Service / SPI via the {@link RequestExecutorFactory} class
+     * <p>
      * {@link com.okta.sdk.impl.client.BaseClient#createRequestExecutor}
      *
      * @param requestExecutorFactory that should be used to create the RequestExecutor

--- a/api/src/main/java/com/okta/sdk/client/ClientBuilder.java
+++ b/api/src/main/java/com/okta/sdk/client/ClientBuilder.java
@@ -433,8 +433,8 @@ public interface ClientBuilder {
     ClientBuilder setRetryMaxAttempts(int maxAttempts);
 
     /**
-     * Sets the {@link RequestExecutorFactory},
-     * otherwise it will be loaded as a Service / SPI via the {@link RequestExecutorFactory} class
+     * Sets the {@link RequestExecutorFactory}, otherwise it will be loaded as a Service / SPI 
+     * via the {@link RequestExecutorFactory} class.
      *
      * @param requestExecutorFactory that should be used to create the RequestExecutor
      * @return the ClientBuilder instance for method chaining

--- a/api/src/main/java/com/okta/sdk/client/ClientBuilder.java
+++ b/api/src/main/java/com/okta/sdk/client/ClientBuilder.java
@@ -16,6 +16,7 @@
  */
 package com.okta.sdk.client;
 
+import com.okta.commons.http.RequestExecutorFactory;
 import com.okta.commons.http.config.Proxy;
 import com.okta.sdk.authc.credentials.ClientCredentials;
 import com.okta.sdk.cache.CacheManager;
@@ -430,6 +431,15 @@ public interface ClientBuilder {
      * @return the ClientBuilder instance for method chaining
      */
     ClientBuilder setRetryMaxAttempts(int maxAttempts);
+
+    /**
+     * Sets the {@link RequestExecutorFactory}, otherwise the one will be used from the classpath.
+     * {@link com.okta.sdk.impl.client.BaseClient#createRequestExecutor}
+     *
+     * @param requestExecutorFactory that should be used to create the RequestExecutor
+     * @return the ClientBuilder instance for method chaining
+     */
+    ClientBuilder setRequestExecutorFactory(RequestExecutorFactory requestExecutorFactory);
 
     /**
      * Constructs a new {@link Client} instance based on the ClientBuilder's current configuration state.

--- a/impl/src/main/java/com/okta/sdk/impl/client/BaseClient.java
+++ b/impl/src/main/java/com/okta/sdk/impl/client/BaseClient.java
@@ -42,12 +42,12 @@ public abstract class BaseClient implements DataStore {
     private final InternalDataStore dataStore;
 
     public BaseClient(ClientConfiguration clientConfiguration, CacheManager cacheManager) {
-        this(clientConfiguration, cacheManager, createRequestExecutor(clientConfiguration));
+        this(clientConfiguration, cacheManager, null);
     }
 
     public BaseClient(ClientConfiguration clientConfiguration, CacheManager cacheManager, RequestExecutor requestExecutor) {
         Assert.notNull(clientConfiguration, "clientConfiguration argument cannot be null.");
-        this.dataStore = createDataStore(requestExecutor,
+        this.dataStore = createDataStore(requestExecutor != null ? requestExecutor : createRequestExecutor(clientConfiguration),
                                          clientConfiguration.getBaseUrlResolver(),
                                          clientConfiguration.getClientCredentialsResolver(),
                                          cacheManager);
@@ -72,7 +72,7 @@ public abstract class BaseClient implements DataStore {
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    protected static RequestExecutor createRequestExecutor(ClientConfiguration clientConfiguration) {
+    protected RequestExecutor createRequestExecutor(ClientConfiguration clientConfiguration) {
 
         String msg = "Unable to find a '" + RequestExecutorFactory.class.getName() + "' " +
                 "implementation on the classpath.  Please ensure you have added the " +

--- a/impl/src/main/java/com/okta/sdk/impl/client/BaseClient.java
+++ b/impl/src/main/java/com/okta/sdk/impl/client/BaseClient.java
@@ -42,8 +42,11 @@ public abstract class BaseClient implements DataStore {
     private final InternalDataStore dataStore;
 
     public BaseClient(ClientConfiguration clientConfiguration, CacheManager cacheManager) {
+        this(clientConfiguration, cacheManager, createRequestExecutor(clientConfiguration));
+    }
+
+    public BaseClient(ClientConfiguration clientConfiguration, CacheManager cacheManager, RequestExecutor requestExecutor) {
         Assert.notNull(clientConfiguration, "clientConfiguration argument cannot be null.");
-        RequestExecutor requestExecutor = createRequestExecutor(clientConfiguration);
         this.dataStore = createDataStore(requestExecutor,
                                          clientConfiguration.getBaseUrlResolver(),
                                          clientConfiguration.getClientCredentialsResolver(),
@@ -69,7 +72,7 @@ public abstract class BaseClient implements DataStore {
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    protected RequestExecutor createRequestExecutor(ClientConfiguration clientConfiguration) {
+    protected static RequestExecutor createRequestExecutor(ClientConfiguration clientConfiguration) {
 
         String msg = "Unable to find a '" + RequestExecutorFactory.class.getName() + "' " +
                 "implementation on the classpath.  Please ensure you have added the " +

--- a/impl/src/main/java/com/okta/sdk/impl/client/DefaultClientBuilder.java
+++ b/impl/src/main/java/com/okta/sdk/impl/client/DefaultClientBuilder.java
@@ -17,6 +17,7 @@
 package com.okta.sdk.impl.client;
 
 import com.okta.commons.configcheck.ConfigurationValidator;
+import com.okta.commons.http.RequestExecutorFactory;
 import com.okta.commons.http.config.BaseUrlResolver;
 import com.okta.commons.lang.Assert;
 import com.okta.commons.lang.Classes;
@@ -104,6 +105,7 @@ public class DefaultClientBuilder implements ClientBuilder {
     private boolean allowNonHttpsForTesting = false;
 
     private ClientConfiguration clientConfig = new ClientConfiguration();
+    private RequestExecutorFactory requestExecutorFactory;
 
     private AccessTokenRetrieverService accessTokenRetrieverService;
 
@@ -332,6 +334,12 @@ public class DefaultClientBuilder implements ClientBuilder {
     }
 
     @Override
+    public ClientBuilder setRequestExecutorFactory(RequestExecutorFactory requestExecutorFactory) {
+        this.requestExecutorFactory = requestExecutorFactory;
+        return this;
+    }
+
+    @Override
     public Client build() {
         if (!this.clientConfig.isCacheManagerEnabled()) {
             log.debug("CacheManager disabled. Defaulting to DisabledCacheManager");
@@ -375,7 +383,9 @@ public class DefaultClientBuilder implements ClientBuilder {
             this.clientConfig.setClientCredentialsResolver(new DefaultClientCredentialsResolver(oAuth2ClientCredentials));
         }
 
-        return new DefaultClient(clientConfig, cacheManager);
+        return requestExecutorFactory == null
+            ? new DefaultClient(clientConfig, cacheManager)
+            : new DefaultClient(clientConfig, cacheManager, requestExecutorFactory.create(clientConfig));
     }
 
     /**

--- a/impl/src/test/groovy/com/okta/sdk/impl/client/MockClient.groovy
+++ b/impl/src/test/groovy/com/okta/sdk/impl/client/MockClient.groovy
@@ -42,13 +42,7 @@ class MockClient extends DefaultClient {
 
 
     MockClient(ClientConfiguration clientConfig = defaultClientConfig) {
-        super(clientConfig, new DisabledCacheManager())
-    }
-
-    @Override
-    protected RequestExecutor createRequestExecutor(ClientConfiguration clientConfiguration) {
-        mockRequestExecutor = Mockito.mock(RequestExecutor)
-        return mockRequestExecutor
+        super(clientConfig, new DisabledCacheManager(), mockRequestExecutor = Mockito.mock(RequestExecutor))
     }
 
     MockClient withMockResponse(Request request, Response response) {

--- a/swagger-templates/src/main/resources/OktaJavaImpl/api.mustache
+++ b/swagger-templates/src/main/resources/OktaJavaImpl/api.mustache
@@ -16,6 +16,7 @@
 {{>licenseInfo}}
 package {{package}};
 
+import com.okta.commons.http.RequestExecutor;
 import com.okta.sdk.cache.CacheManager;
 import com.okta.sdk.client.AuthenticationScheme;
 import com.okta.commons.http.config.Proxy;
@@ -57,6 +58,18 @@ public class {{classname}} extends com.okta.sdk.impl.client.BaseClient implement
     */
     public {{classname}}(ClientConfiguration clientConfiguration, CacheManager cacheManager) {
         super(clientConfiguration, cacheManager);
+    }
+
+    /**
+    * Instantiates a new Client instance that will communicate with the Okta REST API.  See the class-level
+    * JavaDoc for a usage example.
+    *
+    * @param clientConfiguration  the {@link ClientConfiguration} containing the connection information
+    * @param cacheManager         the {@link CacheManager} that should be used to cache
+    * @param requestExecutor      the {@link RequestExecutor} that should be used to execute requests
+    */
+    public {{classname}}(ClientConfiguration clientConfiguration, CacheManager cacheManager, RequestExecutor requestExecutor) {
+        super(clientConfiguration, cacheManager, requestExecutor);
     }
 
 {{#operation}}{{^vendorExtensions.moved}}


### PR DESCRIPTION
## Issue(s)
https://github.com/okta/okta-sdk-java/issues/574

## Description
Add setter for RequestExecutorFactory to ClientBuilder.

## Category
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [ ] Bugfix
- [ ] Enhancement
- [x] New Feature
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit Test(s)
- [ ] Documentation
