### PR TITLE
OKTA-406629: update filter parameter name

### DIFF
--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/GroupsIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/GroupsIT.groovy
@@ -116,7 +116,7 @@ class GroupsIT extends ITSupport implements CrudTestSupport {
         validateGroup(group, groupName)
 
         // 2. Search the group by search parameter
-        Thread.sleep(1000)
+        Thread.sleep(getTestOperationDelay())
         assertPresent(client.listGroups(null, "profile.name eq \"" + groupName + "\"", null), group)
     }
 

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/GroupsIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/GroupsIT.groovy
@@ -103,6 +103,24 @@ class GroupsIT extends ITSupport implements CrudTestSupport {
     }
 
     @Test
+    @Scenario("search-groups-by-search-parameter")
+    void searchGroupsBySearchParameterTest() {
+
+        String groupName = "Search Test Group ${uniqueTestName}"
+
+        // 1. Create a new group
+        Group group = GroupBuilder.instance()
+            .setName(groupName)
+            .buildAndCreate(client)
+        registerForCleanup(group)
+        validateGroup(group, groupName)
+
+        // 2. Search the group by search parameter
+        Thread.sleep(500)
+        assertPresent(client.listGroups(null, "profile.name eq \"" + groupName + "\"", null), group)
+    }
+
+    @Test
     @Scenario("update-group")
     void updateGroupTest() {
 

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/GroupsIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/GroupsIT.groovy
@@ -116,7 +116,7 @@ class GroupsIT extends ITSupport implements CrudTestSupport {
         validateGroup(group, groupName)
 
         // 2. Search the group by search parameter
-        Thread.sleep(500)
+        Thread.sleep(1000)
         assertPresent(client.listGroups(null, "profile.name eq \"" + groupName + "\"", null), group)
     }
 

--- a/src/swagger/api.yaml
+++ b/src/swagger/api.yaml
@@ -2370,7 +2370,7 @@ paths:
           type: string
         - description: Filter expression for groups
           in: query
-          name: filter
+          name: search
           type: string
         - description: Specifies the pagination cursor for the next page of groups
           in: query


### PR DESCRIPTION
## Issue(s)
https://github.com/okta/okta-sdk-java/issues/593

## Description
'filer' is a wrong query parameter for searching groups

## Category
- [x] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit Test(s)
- [ ] Documentation
