### PR TITLE
OKTA-391589: encode a reference special character

### DIFF
--- a/impl/src/main/java/com/okta/sdk/impl/ds/DefaultDataStore.java
+++ b/impl/src/main/java/com/okta/sdk/impl/ds/DefaultDataStore.java
@@ -573,7 +573,8 @@ public class DefaultDataStore implements InternalDataStore {
         if (!href.startsWith("/")) {
             sb.append("/");
         }
-        sb.append(href);
+        //  encode a reference special character
+        sb.append(href.replace("#", "%23"));
         return sb.toString();
     }
 

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/UsersIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/UsersIT.groovy
@@ -255,6 +255,27 @@ class UsersIT extends ITSupport implements CrudTestSupport {
     }
 
     @Test
+    @Scenario("user-with-special-character")
+    void userWithSpecialCharacterTest() {
+        def password = 'Passw0rd!2@3#'
+        def firstName = 'John'
+        def lastName = 'hashtag'
+        def email = "john-${uniqueTestName}#@example.com"
+
+        User user = UserBuilder.instance()
+                .setEmail(email)
+                .setFirstName(firstName)
+                .setLastName(lastName)
+                .setPassword(password.toCharArray())
+                .buildAndCreate(client)
+        registerForCleanup(user)
+        validateUser(user, firstName, lastName, email)
+
+        Thread.sleep(getTestOperationDelay())
+        assertThat(client.getUser(email), equalTo(user))
+    }
+
+    @Test
     @Scenario("user-role-assign")
     void roleAssignTest() {
 


### PR DESCRIPTION
`client.getUser(email)` method works incorrectly with special characters

## Issue(s)
https://github.com/okta/okta-sdk-java/issues/580

## Description
Hashtag is a special character and in URLs it means a reference. We need to encode it if it was used for the user's email.
[Supported Okta email address characters](https://help.okta.com/en/prod/Content/Topics/Directory/Reference_Directories.htm)

## Category
- [x] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit Test(s)
- [ ] Documentation
