### PR TITLE
OKTA-397604: Obtaining the list groups assigned to the application with the "expand" attribute

### DIFF
--- a/impl/src/main/java/com/okta/sdk/impl/resource/AbstractCollectionResource.java
+++ b/impl/src/main/java/com/okta/sdk/impl/resource/AbstractCollectionResource.java
@@ -206,8 +206,9 @@ public abstract class AbstractCollectionResource<T extends Resource> extends Abs
                 //We can't 'trust' the current page iterator to know if more results exist on the server since it
                 //only represents a single page.
 
-                AbstractCollectionResource nextResource =
-                        getDataStore().getResource(getNextPageUrl(), resource.getClass());
+                AbstractCollectionResource<T> nextResource = queryParams.isEmpty()
+                    ? getDataStore().getResource(getNextPageUrl(), resource.getClass())
+                    : getDataStore().getResource(getNextPageUrl(), resource.getClass(), queryParams);
                 Page<T> nextPage = nextResource.getCurrentPage();
                 Iterator<T> nextIterator = nextPage.getItems().iterator();
 

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/UsersIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/UsersIT.groovy
@@ -16,9 +16,11 @@
 package com.okta.sdk.tests.it
 
 import com.okta.sdk.client.Client
+import com.okta.sdk.impl.resource.DefaultGroupBuilder
 import com.okta.sdk.resource.ExtensibleResource
 import com.okta.sdk.resource.Resource
 import com.okta.sdk.resource.ResourceException
+import com.okta.sdk.resource.application.ApplicationGroupAssignment
 import com.okta.sdk.resource.group.Group
 import com.okta.sdk.resource.group.GroupBuilder
 import com.okta.sdk.resource.policy.PasswordPolicyPasswordSettings
@@ -895,6 +897,30 @@ class UsersIT extends ITSupport implements CrudTestSupport {
             .get(userListFirstPage.getNextPageUrl(), UserList.class)
         assertThat userListSecondPage, notNullValue()
         assertThat userListSecondPage.getProperties().get("currentPage").getProperties().get("items").collect().size(), is(greaterThanOrEqualTo(1))
+    }
+
+    @Test
+    void testListGroupAssignmentsWithExpand() {
+        //  Create more than 20 groups
+        for (int i = 1; i < 30; i++) {
+            registerForCleanup(new DefaultGroupBuilder().setName("test-group_" + i + "_${uniqueTestName}").buildAndCreate(client))
+        }
+
+        //  Fetch the GroupAssignment list in two requests
+        def expandParameter = "group"
+        List<ApplicationGroupAssignment> groupAssignments = client.listApplications().first()
+            .listGroupAssignments(null, expandParameter)
+            .stream()
+            .collect(Collectors.toList())
+
+        //  Make sure both pages (all resources) contain an expand parameter
+        for (ApplicationGroupAssignment groupAssignment : groupAssignments) {
+            def embedded = groupAssignment.getEmbedded()
+            assertThat(embedded, notNullValue())
+            assertThat(embedded.get(expandParameter), notNullValue())
+            assertThat(embedded.get(expandParameter).get("type"), notNullValue())
+            assertThat(embedded.get(expandParameter).get("profile"), notNullValue())
+        }
     }
 
     private void ensureCustomProperties() {


### PR DESCRIPTION
## Issue(s)
https://github.com/okta/okta-sdk-java/issues/592

## Description
`queryParams` was missed to fetch the following resources in the AbstractCollectionResource.

## Category
- [x] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit Test(s)
- [ ] Documentation
