### PR TITLE
Travis CI build fails

### DIFF
--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/AuthorizationServerIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/AuthorizationServerIT.groovy
@@ -219,20 +219,22 @@ class AuthorizationServerIT extends ITSupport {
         registerForCleanup(createdAuthorizationServer)
         assertThat(createdAuthorizationServer, notNullValue())
 
-        // create operation may not take effect immediately in the backend
-        sleep(getTestOperationDelay())
-
         AuthorizationServerList authorizationServerList = client.listAuthorizationServers()
         assertThat(authorizationServerList, notNullValue())
         assertThat(authorizationServerList.size(), greaterThan(0))
         assertPresent(authorizationServerList, createdAuthorizationServer)
 
-        authorizationServerList.forEach({ authServer ->
-            assertThat(authServer.listPolicies(), notNullValue())
-            authServer.listPolicies().forEach({ authPolicy ->
-                assertThat(authPolicy.getId(), notNullValue())
+        authorizationServerList.stream()
+            .filter({
+                authServer -> authServer.getId() == createdAuthorizationServer.getId()
             })
-        })
+            .forEach({
+                authServer ->
+                    assertThat(authServer.listPolicies(), notNullValue())
+                    authServer.listPolicies().forEach({
+                        authPolicy -> assertThat(authPolicy.getId(), notNullValue())
+                    })
+            })
     }
 
     @Test

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/AuthorizationServerIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/AuthorizationServerIT.groovy
@@ -411,7 +411,7 @@ class AuthorizationServerIT extends ITSupport {
             authServer.listPolicies().forEach({ authPolicy ->
                 assertThat(authPolicy, notNullValue())
                 assertThat(authPolicy.getId(), notNullValue())
-                assertThat(authPolicy.listPolicyRules(createdAuthorizationServer.getId()), notNullValue())
+                assertThat(authPolicy.listPolicyRules(authServer.getId()), notNullValue())
             })
         })
     }

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/AuthorizationServerIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/AuthorizationServerIT.groovy
@@ -398,22 +398,24 @@ class AuthorizationServerIT extends ITSupport {
         registerForCleanup(createdAuthorizationServer)
         assertThat(createdAuthorizationServer, notNullValue())
 
-        // create operation may not take effect immediately in the backend
-        sleep(getTestOperationDelay())
-
         AuthorizationServerList authorizationServerList = client.listAuthorizationServers()
 
         assertThat(authorizationServerList, notNullValue())
         assertThat(authorizationServerList.size(), greaterThan(0))
 
-        authorizationServerList.forEach({ authServer ->
-            assertThat(authServer.listPolicies(), notNullValue())
-            authServer.listPolicies().forEach({ authPolicy ->
-                assertThat(authPolicy, notNullValue())
-                assertThat(authPolicy.getId(), notNullValue())
-                assertThat(authPolicy.listPolicyRules(authServer.getId()), notNullValue())
+        authorizationServerList.stream()
+            .filter({
+                authServer -> authServer.getId() == createdAuthorizationServer.getId()
             })
-        })
+            .forEach({
+                authServer ->
+                    assertThat(authServer.listPolicies(), notNullValue())
+                    authServer.listPolicies().forEach({ authPolicy ->
+                        assertThat(authPolicy, notNullValue())
+                        assertThat(authPolicy.getId(), notNullValue())
+                        assertThat(authPolicy.listPolicyRules(authServer.getId()), notNullValue())
+                    })
+            })
     }
 
     @Test

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/GroupRulesIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/GroupRulesIT.groovy
@@ -133,7 +133,7 @@ class GroupRulesIT implements CrudTestSupport {
         // 4. Deactivate the rule and update it
         rule.deactivate()
 
-        rule.name = 'Test group rule updated ${uniqueTestName}'
+        rule.name = ("updated-" + groupRuleName).subSequence(0, 50) //Trim the name to 50 chars (server limit)
         rule.getConditions().getExpression().value = 'user.lastName==\"incorrect\"'
         rule.update()
         rule.activate()

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/SmsTemplateIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/SmsTemplateIT.groovy
@@ -19,6 +19,8 @@ import com.okta.sdk.resource.template.SmsTemplateTranslations
 import com.okta.sdk.resource.template.SmsTemplate
 import com.okta.sdk.resource.template.SmsTemplateType
 import com.okta.sdk.tests.it.util.ITSupport
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.testng.annotations.Test
 
 import static com.okta.sdk.tests.it.util.Util.assertPresent
@@ -32,9 +34,27 @@ import static org.hamcrest.Matchers.*
  */
 class SmsTemplateIT extends ITSupport {
 
+    private final static Logger log = LoggerFactory.getLogger(SmsTemplateIT)
+
     @Test
+    void checkFirst() {
+
+        Optional<SmsTemplate> smsTemplate = client.listSmsTemplates(SmsTemplateType.CODE)
+            .stream()
+            .filter({it.getName().startsWith("java-sdk-it-")})
+            .findFirst()
+
+        if(smsTemplate.isPresent()) {
+            log.info("Another test has created an sms template already. Waiting for " + getTestOperationDelay() + "ms")
+            sleep(getTestOperationDelay())
+        } else {
+            assertThat(smsTemplate.isPresent(), is(false))
+        }
+    }
+
+    @Test(dependsOnMethods = ["checkFirst"])
     void customTemplatesCrudTest() {
-        def templateName = "template-" + UUID.randomUUID().toString()
+        def templateName = "java-sdk-it-" + UUID.randomUUID().toString()
 
         // create translations
         SmsTemplateTranslations smsTemplateTranslations = client.instantiate(SmsTemplateTranslations)

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/SmsTemplateIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/SmsTemplateIT.groovy
@@ -50,6 +50,8 @@ class SmsTemplateIT extends ITSupport {
         } else {
             assertThat(smsTemplate.isPresent(), is(false))
         }
+
+        log.info("Operation delay: "+ getTestOperationDelay() + "ms. This log is just for testing purposes.")
     }
 
     @Test(dependsOnMethods = ["checkFirst"])

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/SmsTemplateIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/SmsTemplateIT.groovy
@@ -104,7 +104,6 @@ class SmsTemplateIT extends ITSupport {
     }
 
     boolean isSmsTemplateAlreadyCreated() {
-
         Optional<SmsTemplate> smsTemplate = client.listSmsTemplates(SmsTemplateType.CODE)
             .stream()
             .filter({ it.getName().startsWith("sdk-it-") })

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/SmsTemplateIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/SmsTemplateIT.groovy
@@ -45,13 +45,11 @@ class SmsTemplateIT extends ITSupport {
             .findFirst()
 
         if(smsTemplate.isPresent()) {
-            log.info("Another test has created an sms template already. Waiting for " + getTestOperationDelay() + "ms")
+            log.info("Another test has created an sms template already. Waiting.")
             sleep(getTestOperationDelay())
         } else {
             assertThat(smsTemplate.isPresent(), is(false))
         }
-
-        log.info("Operation delay: "+ getTestOperationDelay() + "ms. This log is just for testing purposes.")
     }
 
     @Test(dependsOnMethods = ["checkFirst"])

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/SmsTemplateIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/SmsTemplateIT.groovy
@@ -41,7 +41,7 @@ class SmsTemplateIT extends ITSupport {
 
         Optional<SmsTemplate> smsTemplate = client.listSmsTemplates(SmsTemplateType.CODE)
             .stream()
-            .filter({it.getName().startsWith("java-sdk-it-")})
+            .filter({it.getName().startsWith("sdk-it-")})
             .findFirst()
 
         if(smsTemplate.isPresent()) {
@@ -54,7 +54,7 @@ class SmsTemplateIT extends ITSupport {
 
     @Test(dependsOnMethods = ["checkFirst"])
     void customTemplatesCrudTest() {
-        def templateName = "java-sdk-it-" + UUID.randomUUID().toString()
+        def templateName = "sdk-it-" + UUID.randomUUID().toString()
 
         // create translations
         SmsTemplateTranslations smsTemplateTranslations = client.instantiate(SmsTemplateTranslations)


### PR DESCRIPTION
Travis CI build fails
- saveCustomSmsTemplate - Too many custom SMS templates. Only one per type is supported.
- listAuthorizationServerPolicyRulesTest - Resource not found error (appears during parallel builds in Travis)
- listAuthorizationServerPoliciesTest - Resource not found error (appears during parallel builds in Travis)
- groupRuleCrudTest - Api validation failed: name - name: Policy rule name already in use