### PR TITLE
Revert japicmp flag (breakBuildOnBinaryIncompatibleModifications)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <snakeyaml.version>1.26</snakeyaml.version>
         <bouncycastle.version>1.68</bouncycastle.version>
         <jjwt.version>0.11.1</jjwt.version>
-        <okta.sdk.previousVersion>4.1.1</okta.sdk.previousVersion>
+        <okta.sdk.previousVersion>5.0.0</okta.sdk.previousVersion>
         <okta.commons.version>1.2.6</okta.commons.version>
 
         <github.slug>okta/okta-sdk-java</github.slug>

--- a/pom.xml
+++ b/pom.xml
@@ -343,7 +343,7 @@
                         </oldVersion>
                         <parameter>
                             <onlyModified>true</onlyModified>
-                            <breakBuildOnBinaryIncompatibleModifications>false</breakBuildOnBinaryIncompatibleModifications>
+                            <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
                             <breakBuildBasedOnSemanticVersioning>true</breakBuildBasedOnSemanticVersioning>
                             <postAnalysisScript>${root.dir}/src/japicmp/postAnalysisScript.groovy</postAnalysisScript>
                         </parameter>


### PR DESCRIPTION
<!-- 
Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
-->

<!--
Please help us process GitHub Issues faster by providing the following information.

Note: If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->

## Issue(s)
<!-- Reference any existing issue(s) here. -->

## Description
<!-- Add a brief description of the issue. -->

## Category
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [ ] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [x] Configuration Change
- [ ] Versioning Change
- [ ] Unit Test(s)
- [ ] Documentation
