### PR TITLE
Add doc deployment on master builds

### DIFF
--- a/.github/workflows/development_javadoc.yml
+++ b/.github/workflows/development_javadoc.yml
@@ -1,0 +1,29 @@
+name: Build Development Javadoc
+
+on:
+  push:
+    branches:
+     - 'master'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Java JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: 8
+          distribution: adopt-openj9
+          cache: maven
+
+      - name: Build Javadoc for Development version
+        run: mvn -s src/ci/settings.xml -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn install -DskipITs javadoc:aggregate com.okta:okta-doclist-maven-plugin:generate jxr:aggregate -Ppub-docs -Pci
+
+      - name: Deploy Development Version of Javadoc to Github Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./target/gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,25 +18,3 @@ install:
 
 script:
 - "./src/ci/build.sh"
-
-after_success:
-- bash <(curl -s https://codecov.io/bash) -f coverage/target/site/jacoco-aggregate/jacoco.xml
-
-deploy:
-- provider: pages
-  skip_cleanup: true
-  github_token: "$GH_API_KEY"
-  local_dir: target/gh-pages
-  email: developers@okta.com
-  name: Travis CI - Auto Doc Build
-  on:
-    jdk: openjdk8
-    branch: master
-    condition: "$TRAVIS_EVENT_TYPE != cron"
-
-notifications:
-  slack:
-    if: type = cron
-    secure: ivOHHaQvSgTOVi1g/8pvvOigj/gkWdSy23fVTOSejahNO8w6PpVHrVE1mJk29RWFEZlY/xBNqx6Zm0H8XAAVOc12C1tgN2J0RQm4kHXc6t8zMOS5NkuV4V0azP6BdCkcAvBgaks+fx6BYOAzcbHZ7MyV+DrLLmXBQiWFRXL420k=
-  on_success: never
-  on_failure: always

--- a/src/ci/build.sh
+++ b/src/ci/build.sh
@@ -32,10 +32,6 @@ cron () {
 deploy () {
     echo "Running mvn verify"
     ${MVN_CMD} verify -Pci
-
-    # also deploy the javadocs to the site
-    git clone -b gh-pages "https://github.com/${REPO_SLUG}.git" target/gh-pages/
-    ${MVN_CMD} javadoc:aggregate com.okta:okta-doclist-maven-plugin:generate jxr:aggregate -Ppub-docs -Pci
 }
 
 full_build () {


### PR DESCRIPTION
<!-- 
Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
-->

<!--
Please help us process GitHub Issues faster by providing the following information.

Note: If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->

## Issue(s)
N/A

## Description
Moves the building of master branch Javadoc to GitHub Actions.
This removes any GitHub dependencies from Travis files.
Removes codecov bash script

## Category
<!-- If possible, commit unit tests separately from the implementation to simplify validation. -->
- [ ] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [x] Configuration Change
- [ ] Versioning Change
- [ ] Unit Test(s)
- [ ] Documentation
