### PR TITLE
Bunch of ITs disabled for OIE environments

### DIFF
--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/FactorsIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/FactorsIT.groovy
@@ -26,23 +26,17 @@ import com.okta.sdk.resource.user.factor.EmailUserFactorProfile
 import com.okta.sdk.resource.user.factor.FactorProvider
 import com.okta.sdk.resource.user.factor.FactorStatus
 import com.okta.sdk.resource.user.factor.FactorType
-import com.okta.sdk.resource.user.factor.HardwareUserFactor
-import com.okta.sdk.resource.user.factor.HardwareUserFactorProfile
 import com.okta.sdk.resource.user.factor.PushUserFactor
 import com.okta.sdk.resource.user.factor.SecurityQuestionUserFactor
 import com.okta.sdk.resource.user.factor.SecurityQuestionList
 import com.okta.sdk.resource.user.factor.SmsUserFactor
 import com.okta.sdk.resource.user.factor.TokenUserFactor
-import com.okta.sdk.resource.user.factor.TokenUserFactorProfile
 import com.okta.sdk.resource.user.factor.TotpUserFactor
-import com.okta.sdk.resource.user.factor.U2fUserFactor
-import com.okta.sdk.resource.user.factor.U2fUserFactorProfile
 import com.okta.sdk.resource.user.factor.UserFactor
 import com.okta.sdk.resource.user.factor.UserFactorList
 import com.okta.sdk.resource.user.factor.VerifyFactorRequest
 import com.okta.sdk.resource.user.factor.VerifyUserFactorResponse
-import com.okta.sdk.resource.user.factor.WebUserFactor
-import com.okta.sdk.resource.user.factor.WebUserFactorProfile
+import com.okta.sdk.tests.NonOIEEnvironmentOnly
 import com.okta.sdk.tests.it.util.ITSupport
 import org.jboss.aerogear.security.otp.Totp
 import org.testng.annotations.Test
@@ -54,6 +48,7 @@ class FactorsIT extends ITSupport {
 
     private String smsTestNumber = "185 635 15491"
 
+    @NonOIEEnvironmentOnly
     @Test (groups = "group2")
     void factorListTest() {
 
@@ -83,6 +78,7 @@ class FactorsIT extends ITSupport {
                 hasProperty("id", is(securityQuestionUserFactor.getId())))))
     }
 
+    @NonOIEEnvironmentOnly
     @Test (groups = "group2")
     void testSecurityQuestionFactorCreation() {
         Client client = getClient()
@@ -100,6 +96,7 @@ class FactorsIT extends ITSupport {
         assertThat securityQuestionUserFactor.id, notNullValue()
     }
 
+    @NonOIEEnvironmentOnly
     @Test (groups = "group2")
     void testCallFactorCreation() {
         Client client = getClient()
@@ -115,6 +112,7 @@ class FactorsIT extends ITSupport {
         assertThat callUserFactor.id, notNullValue()
     }
 
+    @NonOIEEnvironmentOnly
     @Test (groups = "group2")
     void testSmsFactorCreation() {
         Client client = getClient()
@@ -130,6 +128,7 @@ class FactorsIT extends ITSupport {
         assertThat smsUserFactor.id, notNullValue()
     }
 
+    @NonOIEEnvironmentOnly
     @Test (groups = "group2")
     void testPushFactorCreation() {
         Client client = getClient()
@@ -156,6 +155,7 @@ class FactorsIT extends ITSupport {
         assertThat factors, iterableWithSize(greaterThan(1))
     }
 
+    @NonOIEEnvironmentOnly
     @Test (groups = "group2")
     void activateTotpFactor() {
         User user = randomUser()
@@ -190,6 +190,7 @@ class FactorsIT extends ITSupport {
         assertThat response.getFactorResult(), is(VerifyUserFactorResponse.FactorResultEnum.SUCCESS)
     }
 
+    @NonOIEEnvironmentOnly
     @Test (groups = "group2")
     void testEmailUserFactor() {
         User user = randomUser()
@@ -213,6 +214,7 @@ class FactorsIT extends ITSupport {
         assertThat response.getFactorResult(), is(VerifyUserFactorResponse.FactorResultEnum.CHALLENGE)
     }
 
+    @NonOIEEnvironmentOnly
     @Test (groups = "group2")
     void testGoogleTotpUserFactorCreation() {
         User user = randomUser()
@@ -228,6 +230,7 @@ class FactorsIT extends ITSupport {
         assertThat tokenUserFactor.getStatus(), is(FactorStatus.PENDING_ACTIVATION)
     }
 
+    @NonOIEEnvironmentOnly
     @Test (groups = "group2")
     void deleteFactorTest() {
 

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/PolicyRulesIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/PolicyRulesIT.groovy
@@ -19,6 +19,7 @@ import com.okta.sdk.client.Client
 import com.okta.sdk.resource.policy.*
 import com.okta.sdk.resource.policy.rule.PasswordPolicyRuleBuilder
 import com.okta.sdk.resource.policy.rule.SignOnPolicyRuleBuilder
+import com.okta.sdk.tests.NonOIEEnvironmentOnly
 import com.okta.sdk.tests.it.util.ITSupport
 import org.testng.annotations.Test
 
@@ -158,6 +159,7 @@ class PolicyRulesIT extends ITSupport implements CrudTestSupport {
     }
 
     @Test (groups = "group2")
+    @NonOIEEnvironmentOnly
     void createOktaSignOnRadiusPolicyRule() {
 
         def group = randomGroup()

--- a/integration-tests/src/test/java/com/okta/sdk/tests/ConditionalSkipTestAnalyzer.java
+++ b/integration-tests/src/test/java/com/okta/sdk/tests/ConditionalSkipTestAnalyzer.java
@@ -1,0 +1,24 @@
+package com.okta.sdk.tests;
+
+import com.okta.sdk.tests.it.util.ITSupport;
+import org.testng.IInvokedMethod;
+import org.testng.IInvokedMethodListener;
+import org.testng.ITestResult;
+import org.testng.SkipException;
+
+import java.lang.reflect.Method;
+
+public class ConditionalSkipTestAnalyzer implements IInvokedMethodListener {
+
+    @Override
+    public void beforeInvocation(IInvokedMethod invokedMethod, ITestResult testResult) {
+        IInvokedMethodListener.super.beforeInvocation(invokedMethod, testResult);
+        Method method = testResult.getMethod().getConstructorOrMethod().getMethod();
+        if (method == null) {
+            return;
+        }
+        if (method.isAnnotationPresent(NonOIEEnvironmentOnly.class) && ITSupport.isOIEEnvironment) {
+            throw new SkipException("The " + method.getName() + " test shouldn't be run for OIE Environment");
+        }
+    }
+}

--- a/integration-tests/src/test/java/com/okta/sdk/tests/ConditionalSkipTestAnalyzer.java
+++ b/integration-tests/src/test/java/com/okta/sdk/tests/ConditionalSkipTestAnalyzer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.okta.sdk.tests;
 
 import com.okta.sdk.tests.it.util.ITSupport;

--- a/integration-tests/src/test/java/com/okta/sdk/tests/NonOIEEnvironmentOnly.java
+++ b/integration-tests/src/test/java/com/okta/sdk/tests/NonOIEEnvironmentOnly.java
@@ -1,0 +1,11 @@
+package com.okta.sdk.tests;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface NonOIEEnvironmentOnly {
+}

--- a/integration-tests/src/test/java/com/okta/sdk/tests/NonOIEEnvironmentOnly.java
+++ b/integration-tests/src/test/java/com/okta/sdk/tests/NonOIEEnvironmentOnly.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.okta.sdk.tests;
 
 import java.lang.annotation.ElementType;


### PR DESCRIPTION
## Issue(s)
For OIE environment a bunch of ITs works incorrectly.
So I've created an annotation @NonOIEEnvironmentOnly.
This annotation is used to mark ITs which is incompatible with OIE env.
