### PR TITLE
x-okta-known-values support

### DIFF
--- a/impl/src/main/java/com/okta/sdk/impl/resource/identity/provider/FacebookIdentityProviderBuilder.java
+++ b/impl/src/main/java/com/okta/sdk/impl/resource/identity/provider/FacebookIdentityProviderBuilder.java
@@ -36,7 +36,7 @@ public class FacebookIdentityProviderBuilder extends DefaultIdentityProviderBuil
     public IdentityProvider buildAndCreate(Client client) {
 
         IdentityProvider createdIdp = client.createIdentityProvider(client.instantiate(IdentityProvider.class)
-            .setType(IdentityProvider.TypeEnum.FACEBOOK)
+            .setType(IdentityProvider.TypeKnownValues.FACEBOOK)
             .setName(name)
             .setProtocol(client.instantiate(Protocol.class)
                 .setType(Protocol.TypeEnum.OAUTH2)

--- a/impl/src/main/java/com/okta/sdk/impl/resource/identity/provider/GoogleIdentityProviderBuilder.java
+++ b/impl/src/main/java/com/okta/sdk/impl/resource/identity/provider/GoogleIdentityProviderBuilder.java
@@ -36,7 +36,7 @@ public class GoogleIdentityProviderBuilder extends DefaultIdentityProviderBuilde
     public IdentityProvider buildAndCreate(Client client) {
 
         return client.createIdentityProvider(client.instantiate(IdentityProvider.class)
-            .setType(IdentityProvider.TypeEnum.GOOGLE)
+            .setType(IdentityProvider.TypeKnownValues.GOOGLE)
             .setName(name)
             .setProtocol(client.instantiate(Protocol.class)
                 .setType(Protocol.TypeEnum.OIDC)

--- a/impl/src/main/java/com/okta/sdk/impl/resource/identity/provider/LinkedInIdentityProviderBuilder.java
+++ b/impl/src/main/java/com/okta/sdk/impl/resource/identity/provider/LinkedInIdentityProviderBuilder.java
@@ -36,7 +36,7 @@ public class LinkedInIdentityProviderBuilder extends DefaultIdentityProviderBuil
     public IdentityProvider buildAndCreate(Client client) {
 
         return client.createIdentityProvider(client.instantiate(IdentityProvider.class)
-            .setType(IdentityProvider.TypeEnum.LINKEDIN)
+            .setType(IdentityProvider.TypeKnownValues.LINKEDIN)
             .setName(name)
             .setProtocol(client.instantiate(Protocol.class)
                 .setType(Protocol.TypeEnum.OAUTH2)

--- a/impl/src/main/java/com/okta/sdk/impl/resource/identity/provider/MicrosoftIdentityProviderBuilder.java
+++ b/impl/src/main/java/com/okta/sdk/impl/resource/identity/provider/MicrosoftIdentityProviderBuilder.java
@@ -36,7 +36,7 @@ public class MicrosoftIdentityProviderBuilder extends DefaultIdentityProviderBui
     public IdentityProvider buildAndCreate(Client client) {
 
         return client.createIdentityProvider(client.instantiate(IdentityProvider.class)
-            .setType(IdentityProvider.TypeEnum.MICROSOFT)
+            .setType(IdentityProvider.TypeKnownValues.MICROSOFT)
             .setName(name)
             .setProtocol(client.instantiate(Protocol.class)
                 .setType(Protocol.TypeEnum.OIDC)

--- a/impl/src/main/java/com/okta/sdk/impl/resource/identity/provider/OidcIdentityProviderBuilder.java
+++ b/impl/src/main/java/com/okta/sdk/impl/resource/identity/provider/OidcIdentityProviderBuilder.java
@@ -170,7 +170,7 @@ public class OidcIdentityProviderBuilder extends DefaultIdentityProviderBuilder<
     @Override
     public IdentityProvider buildAndCreate(Client client) {
         return client.createIdentityProvider(client.instantiate(IdentityProvider.class)
-            .setType(IdentityProvider.TypeEnum.OIDC)
+            .setType(IdentityProvider.TypeKnownValues.OIDC)
             .setName(name)
             .setIssuerMode(issuerMode)
             .setProtocol(client.instantiate(Protocol.class)

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/FactorsIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/FactorsIT.groovy
@@ -26,23 +26,17 @@ import com.okta.sdk.resource.user.factor.EmailUserFactorProfile
 import com.okta.sdk.resource.user.factor.FactorProvider
 import com.okta.sdk.resource.user.factor.FactorStatus
 import com.okta.sdk.resource.user.factor.FactorType
-import com.okta.sdk.resource.user.factor.HardwareUserFactor
-import com.okta.sdk.resource.user.factor.HardwareUserFactorProfile
 import com.okta.sdk.resource.user.factor.PushUserFactor
 import com.okta.sdk.resource.user.factor.SecurityQuestionUserFactor
 import com.okta.sdk.resource.user.factor.SecurityQuestionList
 import com.okta.sdk.resource.user.factor.SmsUserFactor
 import com.okta.sdk.resource.user.factor.TokenUserFactor
-import com.okta.sdk.resource.user.factor.TokenUserFactorProfile
 import com.okta.sdk.resource.user.factor.TotpUserFactor
-import com.okta.sdk.resource.user.factor.U2fUserFactor
-import com.okta.sdk.resource.user.factor.U2fUserFactorProfile
 import com.okta.sdk.resource.user.factor.UserFactor
 import com.okta.sdk.resource.user.factor.UserFactorList
 import com.okta.sdk.resource.user.factor.VerifyFactorRequest
 import com.okta.sdk.resource.user.factor.VerifyUserFactorResponse
-import com.okta.sdk.resource.user.factor.WebUserFactor
-import com.okta.sdk.resource.user.factor.WebUserFactorProfile
+import com.okta.sdk.tests.NonOIEEnvironmentOnly
 import com.okta.sdk.tests.it.util.ITSupport
 import org.jboss.aerogear.security.otp.Totp
 import org.testng.annotations.Test
@@ -54,6 +48,7 @@ class FactorsIT extends ITSupport {
 
     private String smsTestNumber = "185 635 15491"
 
+    @NonOIEEnvironmentOnly
     @Test (groups = "group2")
     void factorListTest() {
 
@@ -83,6 +78,7 @@ class FactorsIT extends ITSupport {
                 hasProperty("id", is(securityQuestionUserFactor.getId())))))
     }
 
+    @NonOIEEnvironmentOnly
     @Test (groups = "group2")
     void testSecurityQuestionFactorCreation() {
         Client client = getClient()
@@ -100,6 +96,7 @@ class FactorsIT extends ITSupport {
         assertThat securityQuestionUserFactor.id, notNullValue()
     }
 
+    @NonOIEEnvironmentOnly
     @Test (groups = "group2")
     void testCallFactorCreation() {
         Client client = getClient()
@@ -115,6 +112,7 @@ class FactorsIT extends ITSupport {
         assertThat callUserFactor.id, notNullValue()
     }
 
+    @NonOIEEnvironmentOnly
     @Test (groups = "group2")
     void testSmsFactorCreation() {
         Client client = getClient()
@@ -130,6 +128,7 @@ class FactorsIT extends ITSupport {
         assertThat smsUserFactor.id, notNullValue()
     }
 
+    @NonOIEEnvironmentOnly
     @Test (groups = "group2")
     void testPushFactorCreation() {
         Client client = getClient()
@@ -156,6 +155,7 @@ class FactorsIT extends ITSupport {
         assertThat factors, iterableWithSize(greaterThan(1))
     }
 
+    @NonOIEEnvironmentOnly
     @Test (groups = "group2")
     void activateTotpFactor() {
         User user = randomUser()
@@ -190,6 +190,7 @@ class FactorsIT extends ITSupport {
         assertThat response.getFactorResult(), is(VerifyUserFactorResponse.FactorResultEnum.SUCCESS)
     }
 
+    @NonOIEEnvironmentOnly
     @Test (groups = "group2")
     void testEmailUserFactor() {
         User user = randomUser()
@@ -213,6 +214,7 @@ class FactorsIT extends ITSupport {
         assertThat response.getFactorResult(), is(VerifyUserFactorResponse.FactorResultEnum.CHALLENGE)
     }
 
+    @NonOIEEnvironmentOnly
     @Test (groups = "group2")
     void testGoogleTotpUserFactorCreation() {
         User user = randomUser()
@@ -228,6 +230,7 @@ class FactorsIT extends ITSupport {
         assertThat tokenUserFactor.getStatus(), is(FactorStatus.PENDING_ACTIVATION)
     }
 
+    @NonOIEEnvironmentOnly
     @Test (groups = "group2")
     void deleteFactorTest() {
 

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/PolicyRulesIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/PolicyRulesIT.groovy
@@ -19,6 +19,7 @@ import com.okta.sdk.client.Client
 import com.okta.sdk.resource.policy.*
 import com.okta.sdk.resource.policy.rule.PasswordPolicyRuleBuilder
 import com.okta.sdk.resource.policy.rule.SignOnPolicyRuleBuilder
+import com.okta.sdk.tests.NonOIEEnvironmentOnly
 import com.okta.sdk.tests.it.util.ITSupport
 import org.testng.annotations.Test
 
@@ -158,6 +159,7 @@ class PolicyRulesIT extends ITSupport implements CrudTestSupport {
     }
 
     @Test (groups = "group2")
+    @NonOIEEnvironmentOnly
     void createOktaSignOnRadiusPolicyRule() {
 
         def group = randomGroup()

--- a/integration-tests/src/test/java/com/okta/sdk/tests/ConditionalSkipTestAnalyzer.java
+++ b/integration-tests/src/test/java/com/okta/sdk/tests/ConditionalSkipTestAnalyzer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.sdk.tests;
+
+import com.okta.sdk.tests.it.util.ITSupport;
+import org.testng.IInvokedMethod;
+import org.testng.IInvokedMethodListener;
+import org.testng.ITestResult;
+import org.testng.SkipException;
+
+import java.lang.reflect.Method;
+
+public class ConditionalSkipTestAnalyzer implements IInvokedMethodListener {
+
+    @Override
+    public void beforeInvocation(IInvokedMethod invokedMethod, ITestResult testResult) {
+        IInvokedMethodListener.super.beforeInvocation(invokedMethod, testResult);
+        Method method = testResult.getMethod().getConstructorOrMethod().getMethod();
+        if (method == null) {
+            return;
+        }
+        if (method.isAnnotationPresent(NonOIEEnvironmentOnly.class) && ITSupport.isOIEEnvironment) {
+            throw new SkipException("The " + method.getName() + " test shouldn't be run for OIE Environment");
+        }
+    }
+}

--- a/integration-tests/src/test/java/com/okta/sdk/tests/NonOIEEnvironmentOnly.java
+++ b/integration-tests/src/test/java/com/okta/sdk/tests/NonOIEEnvironmentOnly.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.sdk.tests;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface NonOIEEnvironmentOnly {
+}

--- a/src/swagger/api.yaml
+++ b/src/swagger/api.yaml
@@ -10862,7 +10862,7 @@ components:
           - INACTIVE
         type:
           type: string
-          enum:
+          x-okta-known-values:
           - SAML2
           - GOOGLE
           - FACEBOOK

--- a/swagger-templates/src/main/java/com/okta/swagger/codegen/AbstractOktaJavaClientCodegen.java
+++ b/swagger-templates/src/main/java/com/okta/swagger/codegen/AbstractOktaJavaClientCodegen.java
@@ -719,6 +719,12 @@ public abstract class AbstractOktaJavaClientCodegen extends AbstractJavaCodegen 
                 property.datatypeWithEnum = property.baseType + "<" + property.complexType + ">";
             }
 
+            if(property.getVendorExtensions().containsKey("x-okta-known-values")) {
+                property.getVendorExtensions().put("x-okta-known-values-exists", true);
+                property.getVendorExtensions()
+                    .put("x-okta-known-values-class-name", property.getNameInCamelCase() + "KnownValues");
+            }
+
             String datatype = property.datatype;
             if (datatype != null
                     && datatype.matches(".+List$")

--- a/swagger-templates/src/main/resources/OktaJava/modelInterface.mustache
+++ b/swagger-templates/src/main/resources/OktaJava/modelInterface.mustache
@@ -33,9 +33,17 @@ public interface {{classname}} extends ExtensibleResource{{#parent}}, {{.}}{{/pa
     {{{datatypeWithEnum}}} {{getter}}();
 {{^vendorExtensions.x-is-read-only}}
 
+    {{#vendorExtensions.x-okta-known-values-exists}}
+    /**
+    * OKTA known values declared in @{{{vendorExtensions.x-okta-known-values-class-name}}}
+    */
+    {{/vendorExtensions.x-okta-known-values-exists}}
     {{classname}} {{setter}}({{{datatypeWithEnum}}} {{name}});
 {{/vendorExtensions.x-is-read-only}}
 
+{{#vendorExtensions.x-okta-known-values-exists}}
+    {{>modelKnownValues}}
+{{/vendorExtensions.x-okta-known-values-exists}}
 {{#isEnum}}
     {{^isContainer}}
 {{>modelInnerEnum}}

--- a/swagger-templates/src/main/resources/OktaJava/modelInterface.mustache
+++ b/swagger-templates/src/main/resources/OktaJava/modelInterface.mustache
@@ -35,7 +35,7 @@ public interface {{classname}} extends ExtensibleResource{{#parent}}, {{.}}{{/pa
 
     {{#vendorExtensions.x-okta-known-values-exists}}
     /**
-    * OKTA known values declared in @{{{vendorExtensions.x-okta-known-values-class-name}}}
+    * List of OKTA known values declared in {@link {{{vendorExtensions.x-okta-known-values-class-name}}} }
     */
     {{/vendorExtensions.x-okta-known-values-exists}}
     {{classname}} {{setter}}({{{datatypeWithEnum}}} {{name}});

--- a/swagger-templates/src/main/resources/OktaJava/modelKnownValues.mustache
+++ b/swagger-templates/src/main/resources/OktaJava/modelKnownValues.mustache
@@ -14,7 +14,7 @@
     limitations under the License.
 }}
 /**
-* Okta Known Values for {{{nameInCamelCase}}}
+* Okta Known Values for '{{{name}}}' property
 */
 public static class {{#vendorExtensions.x-okta-known-values-class-name}}{{{.}}}{{/vendorExtensions.x-okta-known-values-class-name}} {
 

--- a/swagger-templates/src/main/resources/OktaJava/modelKnownValues.mustache
+++ b/swagger-templates/src/main/resources/OktaJava/modelKnownValues.mustache
@@ -1,0 +1,25 @@
+{{!
+    Copyright 2017 Okta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+}}
+/**
+* Okta Known Values for {{{nameInCamelCase}}}
+*/
+public static class {{#vendorExtensions.x-okta-known-values-class-name}}{{{.}}}{{/vendorExtensions.x-okta-known-values-class-name}} {
+
+    {{#vendorExtensions.x-okta-known-values}}
+    public static final String {{{.}}} = "{{{.}}}";
+    {{/vendorExtensions.x-okta-known-values}}
+}
+


### PR DESCRIPTION
## Issue(s)
Add codegen support for new tag `x-okta-known-values` and change Enum type to String
Origin: [OKTA-423868](https://oktainc.atlassian.net/browse/OKTA-423868)

