### PR TITLE
In case proxy username is not provided do not use CredentialsProvider…

### DIFF
--- a/impl/src/main/java/com/okta/sdk/impl/client/DefaultClientBuilder.java
+++ b/impl/src/main/java/com/okta/sdk/impl/client/DefaultClientBuilder.java
@@ -456,13 +456,15 @@ public class DefaultClientBuilder implements ClientBuilder {
         if (clientConfig.getProxy() != null) {
             clientBuilder.useSystemProperties();
             clientBuilder.setProxy(new HttpHost(clientConfig.getProxyHost(), clientConfig.getProxyPort()));
-            final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
-            AuthScope authScope = new AuthScope(clientConfig.getProxyHost(), clientConfig.getProxyPort());
-            UsernamePasswordCredentials usernamePasswordCredentials =
-                new UsernamePasswordCredentials(clientConfig.getProxyUsername(), clientConfig.getProxyPassword());
-            credentialsProvider.setCredentials(authScope, usernamePasswordCredentials);
-            clientBuilder.setDefaultCredentialsProvider(credentialsProvider);
-            clientBuilder.setProxyAuthenticationStrategy(new ProxyAuthenticationStrategy());
+            if (clientConfig.getProxyUsername() != null) {
+                final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+                AuthScope authScope = new AuthScope(clientConfig.getProxyHost(), clientConfig.getProxyPort());
+                UsernamePasswordCredentials usernamePasswordCredentials =
+                    new UsernamePasswordCredentials(clientConfig.getProxyUsername(), clientConfig.getProxyPassword());
+                credentialsProvider.setCredentials(authScope, usernamePasswordCredentials);
+                clientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+                clientBuilder.setProxyAuthenticationStrategy(new ProxyAuthenticationStrategy());
+            }
         }
 
         final CloseableHttpClient httpClient = clientBuilder.build();


### PR DESCRIPTION
… #874

## Issue(s)
https://github.com/okta/okta-sdk-java/issues/874

## Description
This pull request introduces a fix for the issue encountered when no proxy username is provided in the Okta SDK Java's DefaultClientBuilder. Previously, when a proxy URL was specified without a username, an exception would be thrown during the creation of the DefaultClientBuilder.

The fix modifies the DefaultClientBuilder to handle the absence of a proxy username gracefully. With this fix, when no proxy username is provided, the DefaultClientBuilder will no longer attempt to create a BasicCredentialsProvider for proxy authentication. This ensures that the DefaultClientBuilder can be successfully created even when proxy authentication is not required.

## Category
- [x] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [ ] Library Upgrade
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit or Integration Test(s) 
- [ ] Documentation

## Signoff
- [x] I have submitted a CLA for this PR
- [x] Each commit message explains what the commit does
- [x] I have updated documentation to explain what my PR does
- [ ] My code is covered by tests if required
- [x] I did not edit any automatically generated files
