### PR TITLE
added helper method to get list of mfa policies

### DIFF
--- a/api/src/main/java/com/okta/sdk/helper/PolicyApiHelper.java
+++ b/api/src/main/java/com/okta/sdk/helper/PolicyApiHelper.java
@@ -172,6 +172,38 @@ public class PolicyApiHelper<T extends Policy> extends PolicyApi {
         return typedPolicies;
     }
 
+    public List<MultifactorEnrollmentPolicy> listMfaPolicies(String status,
+                                                             String expand) throws ApiException {
+
+        ApiClient apiClient = getApiClient();
+
+        // create path and map variables
+        String localVarPath = "/api/v1/policies";
+
+        List<Pair> localVarQueryParams = new ArrayList<>();
+        localVarQueryParams.addAll(apiClient.parameterToPair("type", PolicyType.MFA_ENROLL.name()));
+        localVarQueryParams.addAll(apiClient.parameterToPair("status", status));
+        localVarQueryParams.addAll(apiClient.parameterToPair("expand", expand));
+
+        TypeReference<List<MultifactorEnrollmentPolicy>> localVarReturnType = new TypeReference<List<MultifactorEnrollmentPolicy>>() { };
+
+        return apiClient.invokeAPI(
+            localVarPath,
+            HttpMethod.GET.name(),
+            localVarQueryParams,
+            new ArrayList<>(),
+            QUERY_STRING_JOINER.toString(),
+            null,
+            new HashMap<>(),
+            new HashMap<>(),
+            new HashMap<>(),
+            apiClient.selectHeaderAccept(MEDIA_TYPE),
+            apiClient.selectHeaderContentType(new String[] { }),
+            AUTH_NAMES,
+            localVarReturnType
+        );
+    }
+
     public <T extends PolicyRule> T createPolicyRuleOfType(Class<T> classType,
                                                            String policyId,
                                                            PolicyRule policyRule) throws ApiException {

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/PoliciesIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/PoliciesIT.groovy
@@ -340,6 +340,7 @@ class PoliciesIT extends ITSupport {
 
     // disable running them in bacon
     @Test (groups = "bacon")
+    @NonOIEEnvironmentOnly
     void listMfaPolicies() {
 
         List<MultifactorEnrollmentPolicy> mfaPolicies = policyApiHelper.listMfaPolicies(LifecycleStatus.ACTIVE.name(), null)

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/PoliciesIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/PoliciesIT.groovy
@@ -338,7 +338,8 @@ class PoliciesIT extends ITSupport {
         })
     }
 
-    @Test (groups = "group2")
+    // disable running them in bacon
+    @Test (groups = "bacon")
     void listMfaPolicies() {
 
         List<MultifactorEnrollmentPolicy> mfaPolicies = policyApiHelper.listMfaPolicies(LifecycleStatus.ACTIVE.name(), null)

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/PoliciesIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/PoliciesIT.groovy
@@ -337,4 +337,13 @@ class PoliciesIT extends ITSupport {
             assertThat(policyItem, instanceOf(Policy.class))
         })
     }
+
+    @Test (groups = "group2")
+    void listMfaPolicies() {
+
+        List<MultifactorEnrollmentPolicy> mfaPolicies = policyApiHelper.listMfaPolicies(LifecycleStatus.ACTIVE.name(), null)
+
+        assertThat(mfaPolicies, notNullValue())
+        assertThat(mfaPolicies.size(), greaterThanOrEqualTo(0))
+    }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! A few things to know first:
- For us to be able to merge your PR, you must first fill out a CLA. Information on our CLA process can be found at https://developer.okta.com/cla
- For faster reviews and merging, please fill out all sections of this template completely.
- Your title should be concise and explain what the PR does.
- Follow the single responsibility principal with your PR. This PR should adjust a single set of changes. If it is larger than that, please submit multiple PRs
- Please use this template for your PR, so we can understand the purpose. PR's that do not use this template will be closed.
- Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
- If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->

## Issue(s)
<!-- Reference any existing issue(s) here. -->

## Description

Allows MFA Policies (active | inactive) to be easily retrieved with:

```
PolicyApiHelper<Policy> policyApiHelper = new PolicyApiHelper<>(new PolicyApi(client));

List<MultifactorEnrollmentPolicy> mfaPolicies = policyApiHelper.listMfaPolicies(LifecycleStatus.ACTIVE.name(), null);
```

![image](https://github.com/okta/okta-sdk-java/assets/61501885/79591852-ba56-4e66-a251-00c78944142a)

## Category
- [ ] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [ ] Library Upgrade
- [ ] Configuration Change
- [ ] Versioning Change
- [x] Unit or Integration Test(s) 
- [ ] Documentation

## Signoff
- [ ] I have submitted a CLA for this PR
- [ ] Each commit message explains what the commit does
- [ ] I have updated documentation to explain what my PR does
- [x] My code is covered by tests if required
- [ ] I did not edit any automatically generated files
