### PR TITLE
Fix null `_links` field in deserialized `IdentityProvider` object

### DIFF
--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/IdpIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/IdpIT.groovy
@@ -136,6 +136,7 @@ class IdpIT extends ITSupport {
         assertThat(createdIdp.getId(), notNullValue())
         assertThat(createdIdp.getName(), equalTo(name))
         assertThat(createdIdp.getStatus(), equalTo(LifecycleStatus.ACTIVE))
+        assertThat(createdIdp.getLinks(), notNullValue())
 
         // retrieve
         IdentityProvider retrievedIdp = identityProviderApi.getIdentityProvider(createdIdp.getId())
@@ -256,6 +257,7 @@ class IdpIT extends ITSupport {
             equalTo("your-new-client-secret"))
         assertThat(retrievedUpdatedIdp.getProtocol().getIssuer().getUrl(),
             equalTo("https://idp.example.com/new"))
+        assertThat(retrievedUpdatedIdp.getLinks(), notNullValue())
 
         // deactivate
         identityProviderApi.deactivateIdentityProvider(createdIdp.getId())

--- a/src/swagger/api.yaml
+++ b/src/swagger/api.yaml
@@ -25894,7 +25894,9 @@ components:
         type:
           $ref: '#/components/schemas/IdentityProviderType'
         _links:
-          $ref: '#/components/schemas/LinksSelf'
+          type: object
+          additionalProperties:
+              $ref: '#/components/schemas/HrefObjectAppLink'
     IdentityProviderApplicationUser:
       type: object
       properties:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! A few things to know first:
- For us to be able to merge your PR, you must first fill out a CLA. Information on our CLA process can be found at https://developer.okta.com/cla
- For faster reviews and merging, please fill out all sections of this template completely.
- Your title should be concise and explain what the PR does.
- Follow the single responsibility principal with your PR. This PR should adjust a single set of changes. If it is larger than that, please submit multiple PRs
- Please use this template for your PR, so we can understand the purpose. PR's that do not use this template will be closed.
- Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
- If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->

## Issue(s)

`_links` deserializes to `null` due to incorrect spec definition. 

Ref: https://developer.okta.com/docs/reference/api/idps/#identity-provider-object for `IdentityProvider` object sample.

## Description

### Before: ###

![image](https://github.com/okta/okta-sdk-java/assets/61501885/43ac4c16-3348-4878-928e-ab92531ede08)

### After: ###

![image](https://github.com/okta/okta-sdk-java/assets/61501885/845f31ad-7693-46d8-802e-769419cfd1e2)

- Updated IT to assert for non-null `_links` field.

## Category
- [x] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [ ] Library Upgrade
- [ ] Configuration Change
- [ ] Versioning Change
- [x] Unit or Integration Test(s) 
- [ ] Documentation

## Signoff
- [ ] I have submitted a CLA for this PR
- [ ] Each commit message explains what the commit does
- [ ] I have updated documentation to explain what my PR does
- [ ] My code is covered by tests if required
- [ ] I did not edit any automatically generated files
