### PR TITLE
Fix UserProfile serializer ignoring empty and null profile values

### DIFF
--- a/impl/src/main/java/com/okta/sdk/impl/serializer/UserProfileSerializer.java
+++ b/impl/src/main/java/com/okta/sdk/impl/serializer/UserProfileSerializer.java
@@ -42,20 +42,35 @@ public class UserProfileSerializer extends StdSerializer<UserProfile> {
 
         jgen.writeStartObject();
 
+        if (Strings.hasText(userProfile.getEmail())) {
+            jgen.writeStringField(UserProfile.JSON_PROPERTY_EMAIL, userProfile.getEmail());
+        }
+
+        if (Strings.hasText(userProfile.getLogin())) {
+            jgen.writeStringField(UserProfile.JSON_PROPERTY_LOGIN, userProfile.getLogin());
+        }
+
+        if (Strings.hasText(userProfile.getFirstName())) {
+            jgen.writeStringField(UserProfile.JSON_PROPERTY_FIRST_NAME, userProfile.getFirstName());
+        }
+
+        if (Strings.hasText(userProfile.getLastName())) {
+            jgen.writeStringField(UserProfile.JSON_PROPERTY_LAST_NAME, userProfile.getLastName());
+        }
+
+        if (Strings.hasText(userProfile.getLocale())) {
+            jgen.writeStringField(UserProfile.JSON_PROPERTY_LOCALE, userProfile.getLocale());
+        }
+
         jgen.writeStringField(UserProfile.JSON_PROPERTY_CITY, userProfile.getCity());
         jgen.writeStringField(UserProfile.JSON_PROPERTY_COST_CENTER, userProfile.getCostCenter());
         jgen.writeStringField(UserProfile.JSON_PROPERTY_COUNTRY_CODE, userProfile.getCountryCode());
         jgen.writeStringField(UserProfile.JSON_PROPERTY_DEPARTMENT, userProfile.getDepartment());
         jgen.writeStringField(UserProfile.JSON_PROPERTY_DISPLAY_NAME, userProfile.getDisplayName());
         jgen.writeStringField(UserProfile.JSON_PROPERTY_DIVISION, userProfile.getDivision());
-        jgen.writeStringField(UserProfile.JSON_PROPERTY_EMAIL, userProfile.getEmail());
         jgen.writeStringField(UserProfile.JSON_PROPERTY_EMPLOYEE_NUMBER, userProfile.getEmployeeNumber());
-        jgen.writeStringField(UserProfile.JSON_PROPERTY_FIRST_NAME, userProfile.getFirstName());
         jgen.writeStringField(UserProfile.JSON_PROPERTY_HONORIFIC_PREFIX, userProfile.getHonorificPrefix());
         jgen.writeStringField(UserProfile.JSON_PROPERTY_HONORIFIC_SUFFIX, userProfile.getHonorificSuffix());
-        jgen.writeStringField(UserProfile.JSON_PROPERTY_LAST_NAME, userProfile.getLastName());
-        jgen.writeStringField(UserProfile.JSON_PROPERTY_LOCALE, userProfile.getLocale());
-        jgen.writeStringField(UserProfile.JSON_PROPERTY_LOGIN, userProfile.getLogin());
         jgen.writeStringField(UserProfile.JSON_PROPERTY_MANAGER, userProfile.getManager());
         jgen.writeStringField(UserProfile.JSON_PROPERTY_MANAGER_ID, userProfile.getManagerId());
         jgen.writeStringField(UserProfile.JSON_PROPERTY_MIDDLE_NAME, userProfile.getMiddleName());

--- a/impl/src/main/java/com/okta/sdk/impl/serializer/UserProfileSerializer.java
+++ b/impl/src/main/java/com/okta/sdk/impl/serializer/UserProfileSerializer.java
@@ -42,98 +42,37 @@ public class UserProfileSerializer extends StdSerializer<UserProfile> {
 
         jgen.writeStartObject();
 
-        if (Strings.hasText(userProfile.getCity()))
-            jgen.writeStringField(UserProfile.JSON_PROPERTY_CITY, userProfile.getCity());
-
-        if (Strings.hasText(userProfile.getCostCenter()))
-            jgen.writeStringField(UserProfile.JSON_PROPERTY_COST_CENTER, userProfile.getCostCenter());
-
-        if (Strings.hasText(userProfile.getCountryCode()))
-            jgen.writeStringField(UserProfile.JSON_PROPERTY_COUNTRY_CODE, userProfile.getCountryCode());
-
-        if (Strings.hasText(userProfile.getDepartment()))
-            jgen.writeStringField(UserProfile.JSON_PROPERTY_DEPARTMENT, userProfile.getDepartment());
-
-        if (Strings.hasText(userProfile.getDisplayName()))
-            jgen.writeStringField(UserProfile.JSON_PROPERTY_DISPLAY_NAME, userProfile.getDisplayName());
-
-        if (Strings.hasText(userProfile.getDivision()))
-            jgen.writeStringField(UserProfile.JSON_PROPERTY_DIVISION, userProfile.getDivision());
-
-        if (Strings.hasText(userProfile.getEmail()))
-            jgen.writeStringField(UserProfile.JSON_PROPERTY_EMAIL, userProfile.getEmail());
-
-        if (Strings.hasText(userProfile.getEmployeeNumber()))
-            jgen.writeStringField(UserProfile.JSON_PROPERTY_EMPLOYEE_NUMBER, userProfile.getEmployeeNumber());
-
-        if (Strings.hasText(userProfile.getFirstName()))
-            jgen.writeStringField(UserProfile.JSON_PROPERTY_FIRST_NAME, userProfile.getFirstName());
-
-        if (Strings.hasText(userProfile.getHonorificPrefix()))
-            jgen.writeStringField(UserProfile.JSON_PROPERTY_HONORIFIC_PREFIX, userProfile.getHonorificPrefix());
-
-        if (Strings.hasText(userProfile.getHonorificSuffix()))
-            jgen.writeStringField(UserProfile.JSON_PROPERTY_HONORIFIC_SUFFIX, userProfile.getHonorificSuffix());
-
-        if (Strings.hasText(userProfile.getLastName()))
-            jgen.writeStringField(UserProfile.JSON_PROPERTY_LAST_NAME, userProfile.getLastName());
-
-        if (Strings.hasText(userProfile.getLocale()))
-            jgen.writeStringField(UserProfile.JSON_PROPERTY_LOCALE, userProfile.getLocale());
-
-        if (Strings.hasText(userProfile.getLogin()))
-            jgen.writeStringField(UserProfile.JSON_PROPERTY_LOGIN, userProfile.getLogin());
-
-        if (Strings.hasText(userProfile.getManager()))
-            jgen.writeStringField(UserProfile.JSON_PROPERTY_MANAGER, userProfile.getManager());
-
-        if (Strings.hasText(userProfile.getManagerId()))
-            jgen.writeStringField(UserProfile.JSON_PROPERTY_MANAGER_ID, userProfile.getManagerId());
-
-        if (Strings.hasText(userProfile.getMiddleName()))
-            jgen.writeStringField(UserProfile.JSON_PROPERTY_MIDDLE_NAME, userProfile.getMiddleName());
-
-        if (Strings.hasText(userProfile.getMobilePhone()))
-            jgen.writeStringField(UserProfile.JSON_PROPERTY_MOBILE_PHONE, userProfile.getMobilePhone());
-
-        if (Strings.hasText(userProfile.getNickName()))
-            jgen.writeStringField(UserProfile.JSON_PROPERTY_NICK_NAME, userProfile.getNickName());
-
-        if (Strings.hasText(userProfile.getOrganization()))
-            jgen.writeStringField(UserProfile.JSON_PROPERTY_ORGANIZATION, userProfile.getOrganization());
-
-        if (Strings.hasText(userProfile.getPostalAddress()))
-            jgen.writeStringField(UserProfile.JSON_PROPERTY_POSTAL_ADDRESS, userProfile.getPostalAddress());
-
-        if (Strings.hasText(userProfile.getPreferredLanguage()))
-            jgen.writeStringField(UserProfile.JSON_PROPERTY_PREFERRED_LANGUAGE, userProfile.getPreferredLanguage());
-
-        if (Strings.hasText(userProfile.getPrimaryPhone()))
-            jgen.writeStringField(UserProfile.JSON_PROPERTY_PRIMARY_PHONE, userProfile.getPrimaryPhone());
-
-        if (Strings.hasText(userProfile.getProfileUrl()))
-            jgen.writeStringField(UserProfile.JSON_PROPERTY_PROFILE_URL, userProfile.getProfileUrl());
-
-        if (Strings.hasText(userProfile.getSecondEmail()))
-            jgen.writeStringField(UserProfile.JSON_PROPERTY_SECOND_EMAIL, userProfile.getSecondEmail());
-
-        if (Strings.hasText(userProfile.getState()))
-            jgen.writeStringField(UserProfile.JSON_PROPERTY_STATE, userProfile.getState());
-
-        if (Strings.hasText(userProfile.getStreetAddress()))
-            jgen.writeStringField(UserProfile.JSON_PROPERTY_STREET_ADDRESS, userProfile.getStreetAddress());
-
-        if (Strings.hasText(userProfile.getTimezone()))
-            jgen.writeStringField(UserProfile.JSON_PROPERTY_TIMEZONE, userProfile.getTimezone());
-
-        if (Strings.hasText(userProfile.getTitle()))
-            jgen.writeStringField(UserProfile.JSON_PROPERTY_TITLE, userProfile.getTitle());
-
-        if (Strings.hasText(userProfile.getUserType()))
-            jgen.writeStringField(UserProfile.JSON_PROPERTY_USER_TYPE, userProfile.getUserType());
-
-        if (Strings.hasText(userProfile.getZipCode()))
-            jgen.writeStringField(UserProfile.JSON_PROPERTY_ZIP_CODE, userProfile.getZipCode());
+        jgen.writeStringField(UserProfile.JSON_PROPERTY_CITY, userProfile.getCity());
+        jgen.writeStringField(UserProfile.JSON_PROPERTY_COST_CENTER, userProfile.getCostCenter());
+        jgen.writeStringField(UserProfile.JSON_PROPERTY_COUNTRY_CODE, userProfile.getCountryCode());
+        jgen.writeStringField(UserProfile.JSON_PROPERTY_DEPARTMENT, userProfile.getDepartment());
+        jgen.writeStringField(UserProfile.JSON_PROPERTY_DISPLAY_NAME, userProfile.getDisplayName());
+        jgen.writeStringField(UserProfile.JSON_PROPERTY_DIVISION, userProfile.getDivision());
+        jgen.writeStringField(UserProfile.JSON_PROPERTY_EMAIL, userProfile.getEmail());
+        jgen.writeStringField(UserProfile.JSON_PROPERTY_EMPLOYEE_NUMBER, userProfile.getEmployeeNumber());
+        jgen.writeStringField(UserProfile.JSON_PROPERTY_FIRST_NAME, userProfile.getFirstName());
+        jgen.writeStringField(UserProfile.JSON_PROPERTY_HONORIFIC_PREFIX, userProfile.getHonorificPrefix());
+        jgen.writeStringField(UserProfile.JSON_PROPERTY_HONORIFIC_SUFFIX, userProfile.getHonorificSuffix());
+        jgen.writeStringField(UserProfile.JSON_PROPERTY_LAST_NAME, userProfile.getLastName());
+        jgen.writeStringField(UserProfile.JSON_PROPERTY_LOCALE, userProfile.getLocale());
+        jgen.writeStringField(UserProfile.JSON_PROPERTY_LOGIN, userProfile.getLogin());
+        jgen.writeStringField(UserProfile.JSON_PROPERTY_MANAGER, userProfile.getManager());
+        jgen.writeStringField(UserProfile.JSON_PROPERTY_MANAGER_ID, userProfile.getManagerId());
+        jgen.writeStringField(UserProfile.JSON_PROPERTY_MIDDLE_NAME, userProfile.getMiddleName());
+        jgen.writeStringField(UserProfile.JSON_PROPERTY_MOBILE_PHONE, userProfile.getMobilePhone());
+        jgen.writeStringField(UserProfile.JSON_PROPERTY_NICK_NAME, userProfile.getNickName());
+        jgen.writeStringField(UserProfile.JSON_PROPERTY_ORGANIZATION, userProfile.getOrganization());
+        jgen.writeStringField(UserProfile.JSON_PROPERTY_POSTAL_ADDRESS, userProfile.getPostalAddress());
+        jgen.writeStringField(UserProfile.JSON_PROPERTY_PREFERRED_LANGUAGE, userProfile.getPreferredLanguage());
+        jgen.writeStringField(UserProfile.JSON_PROPERTY_PRIMARY_PHONE, userProfile.getPrimaryPhone());
+        jgen.writeStringField(UserProfile.JSON_PROPERTY_PROFILE_URL, userProfile.getProfileUrl());
+        jgen.writeStringField(UserProfile.JSON_PROPERTY_SECOND_EMAIL, userProfile.getSecondEmail());
+        jgen.writeStringField(UserProfile.JSON_PROPERTY_STATE, userProfile.getState());
+        jgen.writeStringField(UserProfile.JSON_PROPERTY_STREET_ADDRESS, userProfile.getStreetAddress());
+        jgen.writeStringField(UserProfile.JSON_PROPERTY_TIMEZONE, userProfile.getTimezone());
+        jgen.writeStringField(UserProfile.JSON_PROPERTY_TITLE, userProfile.getTitle());
+        jgen.writeStringField(UserProfile.JSON_PROPERTY_USER_TYPE, userProfile.getUserType());
+        jgen.writeStringField(UserProfile.JSON_PROPERTY_ZIP_CODE, userProfile.getZipCode());
 
         Map<String, Object> additionalProperties = userProfile.getAdditionalProperties();
 

--- a/impl/src/main/java/com/okta/sdk/impl/serializer/UserProfileSerializer.java
+++ b/impl/src/main/java/com/okta/sdk/impl/serializer/UserProfileSerializer.java
@@ -42,6 +42,8 @@ public class UserProfileSerializer extends StdSerializer<UserProfile> {
 
         jgen.writeStartObject();
 
+        // non-nullable fields
+
         if (Strings.hasText(userProfile.getEmail())) {
             jgen.writeStringField(UserProfile.JSON_PROPERTY_EMAIL, userProfile.getEmail());
         }
@@ -61,6 +63,8 @@ public class UserProfileSerializer extends StdSerializer<UserProfile> {
         if (Strings.hasText(userProfile.getLocale())) {
             jgen.writeStringField(UserProfile.JSON_PROPERTY_LOCALE, userProfile.getLocale());
         }
+
+        // nullable fields
 
         jgen.writeStringField(UserProfile.JSON_PROPERTY_CITY, userProfile.getCity());
         jgen.writeStringField(UserProfile.JSON_PROPERTY_COST_CENTER, userProfile.getCostCenter());


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! A few things to know first:
- For us to be able to merge your PR, you must first fill out a CLA. Information on our CLA process can be found at https://developer.okta.com/cla
- For faster reviews and merging, please fill out all sections of this template completely.
- Your title should be concise and explain what the PR does.
- Follow the single responsibility principal with your PR. This PR should adjust a single set of changes. If it is larger than that, please submit multiple PRs
- Please use this template for your PR, so we can understand the purpose. PR's that do not use this template will be closed.
- Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
- If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->

## Issue(s)

#937 

## Description

null and empty values are actually allowed for partial update (Ref: https://developer.okta.com/docs/reference/api/users/#update-user)

## Category
- [x] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [ ] Library Upgrade
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit or Integration Test(s) 
- [ ] Documentation

## Signoff
- [ ] I have submitted a CLA for this PR
- [ ] Each commit message explains what the commit does
- [ ] I have updated documentation to explain what my PR does
- [ ] My code is covered by tests if required
- [ ] I did not edit any automatically generated files
