### PR TITLE
Replace JDK17 with JDK21 image in CCI Builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,16 +37,16 @@ jobs:
 
   jdk11:
     docker:
-      - image: cimg/openjdk:11.0.18-node
+      - image: cimg/openjdk:11.0.20-node
     environment:
       JVM_OPTS: -Xmx3200m
     resource_class: large
     parallelism: 3
     steps: *build_steps
 
-  jdk17:
+  jdk21:
     docker:
-      - image: cimg/openjdk:17.0.6-node
+      - image: cimg/openjdk:21.0.0-node
     environment:
       JVM_OPTS: -Xmx3200m
     resource_class: large
@@ -55,7 +55,7 @@ jobs:
 
   snyk-scan:
     docker:
-      - image: cimg/openjdk:17.0.6-node
+      - image: cimg/openjdk:21.0.0-node
     steps:
       - checkout
       - run: npm install
@@ -91,7 +91,7 @@ workflows:
       - general-platform-helpers/job-snyk-prepare:
           name: prepare-snyk
           requires:
-            - jdk17
+            - jdk21
       - snyk-scan:
           name: execute-snyk
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ workflows:
       - jdk11:
           requires:
             - cache-secrets
-      - jdk17:
+      - jdk21:
           requires:
             - cache-secrets
       - general-platform-helpers/job-semgrep-prepare:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! A few things to know first:
- For us to be able to merge your PR, you must first fill out a CLA. Information on our CLA process can be found at https://developer.okta.com/cla
- For faster reviews and merging, please fill out all sections of this template completely.
- Your title should be concise and explain what the PR does.
- Follow the single responsibility principal with your PR. This PR should adjust a single set of changes. If it is larger than that, please submit multiple PRs
- Please use this template for your PR, so we can understand the purpose. PR's that do not use this template will be closed.
- Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
- If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->

## Issue(s)
<!-- Reference any existing issue(s) here. -->

## Description

- Upgrade CCI image `11.0.18-node` to `11.0.20-node`.
- Replace CCI image `17.0.6-node` with `21.0.0-node`.

## Category
- [ ] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [ ] Library Upgrade
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit or Integration Test(s) 
- [ ] Documentation

## Signoff
- [ ] I have submitted a CLA for this PR
- [ ] Each commit message explains what the commit does
- [ ] I have updated documentation to explain what my PR does
- [ ] My code is covered by tests if required
- [ ] I did not edit any automatically generated files
