### PR TITLE
OKTA-678098: Fix UserProfile equals()

### DIFF
--- a/api/src/main/resources/custom_templates/pojo.mustache
+++ b/api/src/main/resources/custom_templates/pojo.mustache
@@ -293,8 +293,9 @@ public boolean equals(Object o) {
     }{{#hasVars}}
         {{classname}} {{classVarName}} = ({{classname}}) o;
         return {{#vars}}{{#vendorExtensions.x-is-jackson-optional-nullable}}equalsNullable(this.{{name}}, {{classVarName}}.{{name}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{#isByteArray}}Arrays{{/isByteArray}}{{^isByteArray}}Objects{{/isByteArray}}.equals(this.{{name}}, {{classVarName}}.{{name}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^-last}} &&
-        {{/-last}}{{/vars}}{{#parent}} &&
-        super.equals(o){{/parent}};{{/hasVars}}{{^hasVars}}
+        {{/-last}}{{/vars}};
+        //{{#parent}} && super.equals(o){{/parent}};{{/hasVars}}{{^hasVars}}
+        {{/hasVars}}{{^hasVars}}
         return {{#parent}}super.equals(o){{/parent}}{{^parent}}true{{/parent}};{{/hasVars}}
 {{/useReflectionEqualsHashCode}}
 }{{#vendorExtensions.x-jackson-optional-nullable-helpers}}

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/UsersIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/UsersIT.groovy
@@ -682,6 +682,7 @@ class UsersIT extends ITSupport {
         User updatedUser = userApi.getUser(user.getId())
 
         assertThat(updatedUser.lastUpdated, greaterThan(originalLastUpdated))
+        assertThat(updatedUser.getProfile(), not(user.getProfile()))
         assertThat(updatedUser.getProfile().getProperties().get("nickName"), equalTo("Batman"))
         //assertThat(userProfile.getAdditionalProperties().get("foo"), equalTo("bar"))
     }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! A few things to know first:
- For us to be able to merge your PR, you must first fill out a CLA. Information on our CLA process can be found at https://developer.okta.com/cla
- For faster reviews and merging, please fill out all sections of this template completely.
- Your title should be concise and explain what the PR does.
- Follow the single responsibility principal with your PR. This PR should adjust a single set of changes. If it is larger than that, please submit multiple PRs
- Please use this template for your PR, so we can understand the purpose. PR's that do not use this template will be closed.
- Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
- If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->

## Issue(s)

#966

## Description
<!-- Add a brief description of the issue. Be concise with your summary, but explain what changed. -->

## Category
- [x] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [ ] Library Upgrade
- [ ] Configuration Change
- [ ] Versioning Change
- [x] Unit or Integration Test(s) 
- [ ] Documentation

## Signoff
- [ ] I have submitted a CLA for this PR
- [ ] Each commit message explains what the commit does
- [ ] I have updated documentation to explain what my PR does
- [ ] My code is covered by tests if required
- [ ] I did not edit any automatically generated files
