### PR TITLE
Add automatic support for DPoP

### DIFF
--- a/impl/src/main/java/com/okta/sdk/impl/oauth2/AccessTokenRetrieverServiceImpl.java
+++ b/impl/src/main/java/com/okta/sdk/impl/oauth2/AccessTokenRetrieverServiceImpl.java
@@ -58,7 +58,7 @@ import java.util.*;
 public class AccessTokenRetrieverServiceImpl implements AccessTokenRetrieverService {
     private static final Logger log = LoggerFactory.getLogger(AccessTokenRetrieverServiceImpl.class);
 
-    private static final String TOKEN_URI  = "/oauth2/v1/token";
+    static final String TOKEN_URI  = "/oauth2/v1/token";
 
     private final ClientConfiguration tokenClientConfiguration;
     private final ApiClient apiClient;
@@ -109,6 +109,11 @@ public class AccessTokenRetrieverServiceImpl implements AccessTokenRetrieverServ
             apiClient.setAccessToken(oAuth2AccessToken.getAccessToken());
 
             return oAuth2AccessToken;
+        } catch (DPoPHandshakeException e) {
+            if (e.continueHandshake) {
+                return getOAuth2AccessToken();
+            }
+            throw new OAuth2HttpException(e.getMessage(), e, false);
         } catch (ApiException e) {
             throw new OAuth2HttpException(e.getMessage(), e, e.getCode() == 401);
         } catch (Exception e) {

--- a/impl/src/main/java/com/okta/sdk/impl/oauth2/DPoPHandshakeException.java
+++ b/impl/src/main/java/com/okta/sdk/impl/oauth2/DPoPHandshakeException.java
@@ -1,0 +1,14 @@
+package com.okta.sdk.impl.oauth2;
+
+public class DPoPHandshakeException extends RuntimeException {
+
+    final boolean continueHandshake;
+    final String responseBody;
+
+    DPoPHandshakeException(DPopHandshakeState status, String error) {
+        super(status.message + ". Error response body: " + error);
+        this.continueHandshake = status.continueHandshake;
+        this.responseBody = error;
+    }
+
+}

--- a/impl/src/main/java/com/okta/sdk/impl/oauth2/DPoPInterceptor.java
+++ b/impl/src/main/java/com/okta/sdk/impl/oauth2/DPoPInterceptor.java
@@ -1,0 +1,150 @@
+package com.okta.sdk.impl.oauth2;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.JwtBuilder;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Encoders;
+import io.jsonwebtoken.security.Jwks;
+import io.jsonwebtoken.security.PrivateJwk;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hc.client5.http.classic.ExecChain;
+import org.apache.hc.client5.http.classic.ExecChainHandler;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.time.Instant;
+import java.util.Date;
+import java.util.UUID;
+
+import static com.okta.sdk.impl.oauth2.AccessTokenRetrieverServiceImpl.TOKEN_URI;
+
+/**
+ * Interceptor that handle DPoP handshake during auth and adds DPoP header to regular requests.
+ * It is always enabled, but is only active when a DPoP error is received during auth.
+ *
+ * @see <a href="https://developer.okta.com/docs/guides/dpop/oktaresourceserver/main/">documentation</a>
+ */
+public class DPoPInterceptor implements ExecChainHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(DPoPInterceptor.class);
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String DPOP_HEADER = "DPoP";
+    //nonce is valid for 24 hours, but can only refresh it when doing a token request => start refreshing after 22 hours
+    private static final int NONCE_VALID_SECONDS = 60 * 60 * 22;
+    private static final MessageDigest SHA256; //required to sign ath claim
+
+    static {
+        try {
+            SHA256 = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    //if null, means dpop is not enabled yet
+    private PrivateJwk<PrivateKey, PublicKey, ?> jwk;
+    private String nonce;
+    private Instant nonceValidUntil;
+
+    @Override
+    public ClassicHttpResponse execute(ClassicHttpRequest request, ExecChain.Scope scope, ExecChain execChain)
+        throws IOException, HttpException {
+        boolean tokenRequest = request.getRequestUri().equals(TOKEN_URI);
+        if (tokenRequest && nonce != null && nonceValidUntil.isBefore(Instant.now())) {
+            log.debug("DPoP nonce expired, will refresh it");
+            nonce = null;
+            nonceValidUntil = null;
+        }
+        if (jwk != null) {
+            processRequest(request, tokenRequest);
+        }
+        ClassicHttpResponse response = execChain.proceed(request, scope);
+        if (tokenRequest) {
+            if (response.getCode() == 200 && nonce != null) {
+                log.info("DPoP handshake successful");
+            }
+            if (response.getCode() == 400) {
+                JsonNode errorBody = OBJECT_MAPPER.readTree(response.getEntity().getContent());
+                Header nonceHeader = response.getFirstHeader("dpop-nonce");
+                DPopHandshakeState handshakeState = handleHandshakeResponse(errorBody.get("error"), nonceHeader);
+                throw new DPoPHandshakeException(handshakeState, OBJECT_MAPPER.writeValueAsString(errorBody));
+            }
+        }
+        return response;
+    }
+
+    private void processRequest(HttpRequest request, boolean tokenRequest) {
+        JwtBuilder builder = Jwts.builder()
+            .header()
+            .type("dpop+jwt")
+            .jwk(jwk.toPublicJwk())
+            .and()
+            .claim("htm", request.getMethod())
+            .claim("htu", getUriWithoutQueryString(request))
+            .claim("jti", UUID.randomUUID().toString())
+            .issuedAt(new Date());
+        Header authorization = request.getFirstHeader("Authorization");
+        if (authorization != null) {
+            //already authenticated, need to replace Authorization header prefix and set ath claim
+            String token = authorization.getValue().replaceFirst("^Bearer ", "");
+            request.setHeader("Authorization", DPOP_HEADER + " " + token);
+            byte[] ath = SHA256.digest(token.getBytes(StandardCharsets.UTF_8));
+            builder.claim("ath", Encoders.BASE64URL.encode(ath));
+        } else if (tokenRequest && nonce != null) {
+            //still in handshake, need to set nonce
+            builder.claim("nonce", nonce);
+        }
+        request.addHeader(DPOP_HEADER, builder.signWith(jwk.toKeyPair().getPrivate()).compact());
+    }
+
+    private String getUriWithoutQueryString(HttpRequest request) {
+        try {
+            return StringUtils.substringBefore(request.getUri().toString(), "?");
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private DPopHandshakeState handleHandshakeResponse(JsonNode errorField, Header nonceHeader) {
+        if (errorField != null && errorField.isTextual()) {
+            switch (errorField.textValue()) {
+                case "invalid_dpop_proof": {
+                    if (jwk != null) {
+                        return DPopHandshakeState.REPEATED_INVALID_DPOP_PROOF;
+                    }
+                    log.info("DPoP detected, beginning handshake");
+                    this.jwk = Jwks.builder().keyPair(Jwts.SIG.ES256.keyPair().build()).build();
+                    return DPopHandshakeState.FIRST_INVALID_DPOP_PROOF;
+                }
+                case "use_dpop_nonce": {
+                    if (nonce != null) {
+                        return DPopHandshakeState.REPEATED_USE_DPOP_NONCE;
+                    }
+                    if (nonceHeader == null) {
+                        return DPopHandshakeState.MISSING_DPOP_NONCE_HEADER;
+                    }
+                    log.debug("DPoP nonce obtained, finalizing handshake");
+                    this.nonce = nonceHeader.getValue();
+                    this.nonceValidUntil = Instant.now().plusSeconds(NONCE_VALID_SECONDS);
+                    return DPopHandshakeState.FIRST_USE_DPOP_NONCE;
+                }
+            }
+        }
+        return DPopHandshakeState.UNEXPECTED_STATE;
+    }
+
+}

--- a/impl/src/main/java/com/okta/sdk/impl/oauth2/DPopHandshakeState.java
+++ b/impl/src/main/java/com/okta/sdk/impl/oauth2/DPopHandshakeState.java
@@ -1,0 +1,23 @@
+package com.okta.sdk.impl.oauth2;
+
+enum DPopHandshakeState {
+    
+    //invalid states
+    REPEATED_INVALID_DPOP_PROOF(false, "Invalid sequence, already received invalid_dpop_proof error"),
+    REPEATED_USE_DPOP_NONCE(false, "Invalid sequence, already received use_dpop_nonce error"),
+    MISSING_DPOP_NONCE_HEADER(false, "Invalid sequence, missing dpop-nonce header on use_dpop_nonce error response"),
+    UNEXPECTED_STATE(false, "Unexpected authentication error"),
+    
+    //valid states
+    FIRST_INVALID_DPOP_PROOF(true, "Received invalid_dpop_proof, will provide DPoP header"),
+    FIRST_USE_DPOP_NONCE(true, "Received use_dpop_nonce, will provide nonce");
+
+    final boolean continueHandshake;
+    final String message;
+
+    DPopHandshakeState(boolean continueHandshake, String message) {
+        this.continueHandshake = continueHandshake;
+        this.message = message;
+    }
+    
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! A few things to know first:
- For us to be able to merge your PR, you must first fill out a CLA. Information on our CLA process can be found at https://developer.okta.com/cla
- For faster reviews and merging, please fill out all sections of this template completely.
- Your title should be concise and explain what the PR does.
- Follow the single responsibility principal with your PR. This PR should adjust a single set of changes. If it is larger than that, please submit multiple PRs
- Please use this template for your PR, so we can understand the purpose. PR's that do not use this template will be closed.
- Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
- If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->

## Description
Add support for DPoP: https://developer.okta.com/docs/guides/dpop/oktaresourceserver/main/

This is done with a new DPoPInterceptor that is enabled if authorizationMode=PRIVATE_KEY, but only activates when receiving a DPoP-related error.
There could be a config property to disable it, but the implementation seems safe enough to be always on.

## Category
- [ ] Bugfix
- [ ] Enhancement
- [x] New Feature
- [ ] Library Upgrade
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit or Integration Test(s) 
- [ ] Documentation

## Signoff
- [x] I have submitted a CLA for this PR
- [x] Each commit message explains what the commit does
- [x] I have updated documentation to explain what my PR does
- [x] My code is covered by tests if required
- [x] I did not edit any automatically generated files
