### PR TITLE
Fix NPE when using the no-arg constructor of ApiClient (#1127)

### DIFF
--- a/api/src/main/resources/custom_templates/ApiClient.mustache
+++ b/api/src/main/resources/custom_templates/ApiClient.mustache
@@ -86,7 +86,7 @@ import java.nio.file.Paths;
 import java.lang.reflect.Type;
 import java.net.URI;
 
-import com.okta.commons.http.config.HttpClientConfiguration;
+import com.okta.sdk.cache.Caches;
 import com.okta.sdk.cache.Cache;
 import com.okta.sdk.cache.CacheManager;
 
@@ -156,10 +156,6 @@ protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>
 
     private Cache<String, Object> cache;
 
-    private CacheManager cacheManager;
-
-    private HttpClientConfiguration httpClientConfiguration;
-
     private int statusCode;
     private Map<String, List<String>> responseHeaders;
 
@@ -168,7 +164,10 @@ protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>
         // Methods that can have a request body
         private static List<String> bodyMethods = Arrays.asList("POST", "PUT", "DELETE", "PATCH");
 
-            public ApiClient(CloseableHttpClient httpClient, CacheManager cacheManager, HttpClientConfiguration httpClientConfiguration) {
+            public ApiClient(CloseableHttpClient httpClient, CacheManager cacheManager) {
+            if (httpClient == null) throw new IllegalArgumentException("httpClient cannot be null");
+            if (cacheManager == null) throw new IllegalArgumentException("cacheManager cannot be null");
+
             objectMapper = new ObjectMapper();
             objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
             objectMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
@@ -201,13 +200,11 @@ protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>
 
             this.httpClient = httpClient;
 
-            this.cacheManager = cacheManager;
-            this.httpClientConfiguration = httpClientConfiguration;
             this.cache = cacheManager.getCache("default");
             }
 
             public ApiClient() {
-            this(HttpClients.createDefault(), null, null);
+                this(HttpClients.createDefault(), Caches.newDisabledCacheManager());
             }
 
             public static DateFormat buildDefaultDateFormat() {

--- a/impl/src/main/java/com/okta/sdk/impl/client/DefaultClientBuilder.java
+++ b/impl/src/main/java/com/okta/sdk/impl/client/DefaultClientBuilder.java
@@ -335,7 +335,7 @@ public class DefaultClientBuilder implements ClientBuilder {
             setProxy(httpClientBuilder, clientConfig);
         }
 
-        ApiClient apiClient = new ApiClient(httpClientBuilder.build(), this.cacheManager, this.clientConfig);
+        ApiClient apiClient = new ApiClient(httpClientBuilder.build(), this.cacheManager);
         apiClient.setBasePath(this.clientConfig.getBaseUrl());
 
         String userAgentValue = ApplicationInfo.get().entrySet().stream()

--- a/impl/src/test/groovy/com/okta/sdk/impl/client/DefaultClientBuilderTest.groovy
+++ b/impl/src/test/groovy/com/okta/sdk/impl/client/DefaultClientBuilderTest.groovy
@@ -17,6 +17,7 @@
 package com.okta.sdk.impl.client
 
 import com.okta.sdk.authc.credentials.TokenClientCredentials
+import com.okta.sdk.cache.Caches
 import com.okta.sdk.client.AuthenticationScheme
 import com.okta.sdk.client.AuthorizationMode
 import com.okta.sdk.client.ClientBuilder
@@ -29,6 +30,9 @@ import com.okta.sdk.impl.oauth2.OAuth2HttpException
 import com.okta.sdk.impl.oauth2.OAuth2TokenRetrieverException
 import com.okta.sdk.impl.test.RestoreEnvironmentVariables
 import com.okta.sdk.impl.test.RestoreSystemProperties
+import com.okta.sdk.resource.client.ApiClient
+import com.okta.sdk.resource.client.Configuration
+import org.apache.hc.client5.http.impl.classic.HttpClients
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.testng.annotations.Listeners
@@ -80,6 +84,21 @@ class DefaultClientBuilderTest {
     @Test
     void testBuilder() {
         assertTrue(Clients.builder() instanceof DefaultClientBuilder)
+    }
+
+    @Test
+    void testDefaultApiClient() {
+        Configuration.getDefaultApiClient()
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    void testIncorrectApiClient_nullHttpClient() {
+        new ApiClient(null, Caches.newDisabledCacheManager())
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    void testIncorrectApiClient_nullCacheManager() {
+        new ApiClient(HttpClients.createDefault(), null)
     }
 
     @Test


### PR DESCRIPTION
- Check both httpClient and cacheManager are non-null
- Add unit tests
- Also cleanup unused fields

<!--
Thank you for submitting a pull request! A few things to know first:
- For us to be able to merge your PR, you must first fill out a CLA. Information on our CLA process can be found at https://developer.okta.com/cla
- For faster reviews and merging, please fill out all sections of this template completely.
- Your title should be concise and explain what the PR does.
- Follow the single responsibility principal with your PR. This PR should adjust a single set of changes. If it is larger than that, please submit multiple PRs
- Please use this template for your PR, so we can understand the purpose. PR's that do not use this template will be closed.
- Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
- If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->

## Issue(s)
<!-- Reference any existing issue(s) here. -->

## Description
<!-- Add a brief description of the issue. Be concise with your summary, but explain what changed. -->

## Category
- [x] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [ ] Library Upgrade
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit or Integration Test(s) 
- [ ] Documentation

## Signoff
- [ ] I have submitted a CLA for this PR
- [ ] Each commit message explains what the commit does
- [ ] I have updated documentation to explain what my PR does
- [ ] My code is covered by tests if required
- [ ] I did not edit any automatically generated files
