### PR TITLE
OASv3 - UserSchemaAttributes minLength and maxLength must be nullable

### DIFF
--- a/src/swagger/api.yaml
+++ b/src/swagger/api.yaml
@@ -31373,8 +31373,10 @@ components:
           $ref: '#/components/schemas/UserSchemaAttributeMaster'
         maxLength:
           type: integer
+          nullable: true
         minLength:
           type: integer
+          nullable: true
         mutability:
           type: string
         oneOf:


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! A few things to know first:
- For us to be able to merge your PR, you must first fill out a CLA. Information on our CLA process can be found at https://developer.okta.com/cla
- For faster reviews and merging, please fill out all sections of this template completely.
- Your title should be concise and explain what the PR does.
- Follow the single responsibility principal with your PR. This PR should adjust a single set of changes. If it is larger than that, please submit multiple PRs
- Please use this template for your PR, so we can understand the purpose. PR's that do not use this template will be closed.
- Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
- If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->

## Issue(s)

OKTA-720637

Related to https://github.com/okta/okta-sdk-dotnet/pull/713

## Description

- Make UserSchemaAttribute.MinLength nullable
- Make UserSchemaAttribute.MaxLength nullable

## Category
- [x] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [ ] Library Upgrade
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit or Integration Test(s) 
- [ ] Documentation

## Signoff
- [ ] I have submitted a CLA for this PR
- [ ] Each commit message explains what the commit does
- [ ] I have updated documentation to explain what my PR does
- [ ] My code is covered by tests if required
- [ ] I did not edit any automatically generated files
