### PR TITLE
Fix DPoP when path contains special chars

### DIFF
--- a/impl/src/main/java/com/okta/sdk/impl/oauth2/DPoPInterceptor.java
+++ b/impl/src/main/java/com/okta/sdk/impl/oauth2/DPoPInterceptor.java
@@ -34,8 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -130,8 +128,13 @@ public class DPoPInterceptor implements ExecChainHandler {
 
     private String getUriWithoutQueryString(HttpRequest request) {
         try {
-            return URLDecoder.decode(StringUtils.substringBefore(request.getUri().toString(), "?"), StandardCharsets.UTF_8.name());
-        } catch (URISyntaxException | UnsupportedEncodingException e) {
+            String urlWithoutQueryString = StringUtils.substringBefore(request.getUri().toString(), "?");
+            return URLDecoder.decode(urlWithoutQueryString, StandardCharsets.UTF_8.name())
+                .replace("%", "%25") //must be replaced first
+                .replace(" ", "%20")
+                .replace("\"", "%22")
+                .replace("#", "%23");
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }

--- a/impl/src/test/java/com/okta/sdk/impl/test/SpecialCharsTest.java
+++ b/impl/src/test/java/com/okta/sdk/impl/test/SpecialCharsTest.java
@@ -1,0 +1,59 @@
+package com.okta.sdk.impl.test;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableSet;
+import com.okta.sdk.client.AuthorizationMode;
+import com.okta.sdk.client.Clients;
+import com.okta.sdk.resource.api.RoleApi;
+import com.okta.sdk.resource.client.ApiClient;
+import com.okta.sdk.resource.client.ApiException;
+import org.apache.commons.text.StringEscapeUtils;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+public class SpecialCharsTest {
+
+    public static final String PRIVATE_KEY =
+        "-----BEGIN PRIVATE KEY-----\n" +
+        "PEM_KEY\n" +
+        "Vq8nxYOpGVRtId7gbwRrywqC\n" +
+        "-----END PRIVATE KEY-----\n";
+    public static final String ORG_URL = "https://OKTA_DOMAIN";
+    public static final String CLIENT_ID = "CLIENT_ID";
+    public static final String KID = "KID";
+
+    @Test
+    public void test() {
+        ApiClient apiClient = Clients.builder()
+            .setOrgUrl(ORG_URL)
+            .setAuthorizationMode(AuthorizationMode.PRIVATE_KEY)
+            .setClientId(CLIENT_ID)
+            .setPrivateKey(PRIVATE_KEY)
+            .setKid(KID)
+            .setScopes(ImmutableSet.of("okta.roles.read"))
+            .build();
+        RoleApi roleApi = new RoleApi(apiClient);
+        " %-._~!$'()*,;&=@:+\\\"/#".chars()
+            .mapToObj(c -> "prefix" + (char) c + "suffix")
+            .forEach(label -> {
+                try {
+                    roleApi.getRole(label);
+                } catch (ApiException e) {
+                    String error;
+                    List<String> wwwAuthenticate = e.getResponseHeaders().get("www-authenticate");
+                    if (e.getCode() == 404){
+                        if (e.getMessage().contains(StringEscapeUtils.escapeHtml4(label))) return;
+                        error = "Unexpected 404 message: " + e.getMessage();
+                    } else if (wwwAuthenticate != null) {
+                        error = "www-authenticate error: " + wwwAuthenticate.get(0);
+                    } else {
+                        error = e.getCode() + " error: " + e.getMessage();
+                    }
+                    System.out.println("Failed '" + label + "': " + error);
+                }
+            });
+    }
+
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! A few things to know first:
- For us to be able to merge your PR, you must first fill out a CLA. Information on our CLA process can be found at https://developer.okta.com/cla
- For faster reviews and merging, please fill out all sections of this template completely.
- Your title should be concise and explain what the PR does.
- Follow the single responsibility principal with your PR. This PR should adjust a single set of changes. If it is larger than that, please submit multiple PRs
- Please use this template for your PR, so we can understand the purpose. PR's that do not use this template will be closed.
- Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
- If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->

## Description

Current DPoP implementation does not work when the path to the resource contains some special characters.
This can happen when requesting resources by label, like users, roles or resource sets.

I implement a [test](https://github.com/okta/okta-sdk-java/compare/master...clementdenis:okta-sdk-java:fix_dpop_with_special_chars#diff-7e2be301e14d733117a1ea3a52266b72f8558a2d267746fc6dbb54165fd89aa1)  that tests a lot of characters.
The test itself can't be merged as is, as it's requires setting some variables to connect to a tenant.
I couldn't find a way to integrate this test properly in the existing test suite.

The results of the test are:

- DPoP disabled => these errors are related to incorrect handling of some encoded chars by the API, seems it can't be fixed from the client side, see https://github.com/okta/okta-sdk-dotnet/issues/533:

```
Failed 'prefix;suffix': Unexpected 404 message: {"errorCode":"E0000007","errorSummary":"Not found: Resource not found: prefix (CustomRole)","errorLink":"E0000007","errorId":"oae37-Ad6kKRuKxJK8-zIk02g","errorCauses":[]}
Failed 'prefix\suffix': 400 error: <!doctype html><html lang="en"><head><title>HTTP Status 400 – Bad Request</title><style type="text/css">body {font-family:Tahoma,Arial,sans-serif;} h1, h2, h3, b {color:white;background-color:#525D76;} h1 {font-size:22px;} h2 {font-size:16px;} h3 {font-size:14px;} p {font-size:12px;} a {color:black;} .line {height:1px;background-color:#525D76;border:none;}</style></head><body><h1>HTTP Status 400 – Bad Request</h1></body></html>
Failed 'prefix/suffix': 405 error: {"errorCode":"E0000022","errorSummary":"The endpoint does not support the provided HTTP method","errorLink":"E0000022","errorId":"oaegFYOF8iPTPmAJW_lXnn1NQ","errorCauses":[]}
```

- DPoP enabled with just URLDecoder.decode (current impl) => some characters raise an invalid htu claim error:

```
Failed 'prefix suffix': www-authenticate error: DPoP algs="RS256 RS384 RS512 ES256 ES384 ES512", authorization_uri="http://lyvoc-protov3.oktapreview.com/oauth2/v1/authorize", realm="http://lyvoc-protov3.oktapreview.com", scope="okta.roles.read", error="invalid_dpop_proof", error_description="'htu' claim in the DPoP proof JWT is invalid.", resource="/api/v1/iam/roles/prefix suffix"
Failed 'prefix%suffix': www-authenticate error: DPoP algs="RS256 RS384 RS512 ES256 ES384 ES512", authorization_uri="http://lyvoc-protov3.oktapreview.com/oauth2/v1/authorize", realm="http://lyvoc-protov3.oktapreview.com", scope="okta.roles.read", error="invalid_dpop_proof", error_description="'htu' claim in the DPoP proof JWT is invalid.", resource="/api/v1/iam/roles/prefix%suffix"
Failed 'prefix;suffix': Unexpected 404 message: {"errorCode":"E0000007","errorSummary":"Not found: Resource not found: prefix (CustomRole)","errorLink":"E0000007","errorId":"oae6voX0LPbShCEYRyW-7W7qw","errorCauses":[]}
Failed 'prefix\suffix': 400 error: <!doctype html><html lang="en"><head><title>HTTP Status 400 – Bad Request</title><style type="text/css">body {font-family:Tahoma,Arial,sans-serif;} h1, h2, h3, b {color:white;background-color:#525D76;} h1 {font-size:22px;} h2 {font-size:16px;} h3 {font-size:14px;} p {font-size:12px;} a {color:black;} .line {height:1px;background-color:#525D76;border:none;}</style></head><body><h1>HTTP Status 400 – Bad Request</h1></body></html>
Failed 'prefix"suffix': www-authenticate error: DPoP algs="RS256 RS384 RS512 ES256 ES384 ES512", authorization_uri="http://lyvoc-protov3.oktapreview.com/oauth2/v1/authorize", realm="http://lyvoc-protov3.oktapreview.com", scope="okta.roles.read", error="invalid_dpop_proof", error_description="'htu' claim in the DPoP proof JWT is invalid.", resource="/api/v1/iam/roles/prefix"suffix"
Failed 'prefix/suffix': 405 error: {"errorCode":"E0000022","errorSummary":"The endpoint does not support the provided HTTP method","errorLink":"E0000022","errorId":"oaejfhvnjo8Tmm-mIKFS_G_5A","errorCauses":[]}
Failed 'prefix#suffix': www-authenticate error: DPoP algs="RS256 RS384 RS512 ES256 ES384 ES512", authorization_uri="http://lyvoc-protov3.oktapreview.com/oauth2/v1/authorize", realm="http://lyvoc-protov3.oktapreview.com", scope="okta.roles.read", error="invalid_dpop_proof", error_description="'htu' claim in the DPoP proof JWT is invalid.", resource="/api/v1/iam/roles/prefix#suffix"
```

- DPoP enabled with final code => back to same errors as without DPoP:
```
Failed 'prefix;suffix': Unexpected 404 message: {"errorCode":"E0000007","errorSummary":"Not found: Resource not found: prefix (CustomRole)","errorLink":"E0000007","errorId":"oae5yrODm6QSNaslRZx_cECBg","errorCauses":[]}
Failed 'prefix\suffix': 400 error: <!doctype html><html lang="en"><head><title>HTTP Status 400 – Bad Request</title><style type="text/css">body {font-family:Tahoma,Arial,sans-serif;} h1, h2, h3, b {color:white;background-color:#525D76;} h1 {font-size:22px;} h2 {font-size:16px;} h3 {font-size:14px;} p {font-size:12px;} a {color:black;} .line {height:1px;background-color:#525D76;border:none;}</style></head><body><h1>HTTP Status 400 – Bad Request</h1></body></html>
Failed 'prefix/suffix': 405 error: {"errorCode":"E0000022","errorSummary":"The endpoint does not support the provided HTTP method","errorLink":"E0000022","errorId":"oaeKGPk2lB0SwmS1mZxGNXG5Q","errorCauses":[]}
```

## Category
- [x] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [ ] Library Upgrade
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit or Integration Test(s) 
- [ ] Documentation

## Signoff
- [x] I have submitted a CLA for this PR
- [x] Each commit message explains what the commit does
- [x] I have updated documentation to explain what my PR does
- [x] My code is covered by tests if required
- [x] I did not edit any automatically generated files
