### PR TITLE
Fix DPoPInterceptor thread-safety

### DIFF
--- a/impl/src/main/java/com/okta/sdk/impl/oauth2/DPoPInterceptor.java
+++ b/impl/src/main/java/com/okta/sdk/impl/oauth2/DPoPInterceptor.java
@@ -62,15 +62,14 @@ public class DPoPInterceptor implements ExecChainHandler {
     private static final String DPOP_HEADER = "DPoP";
     //nonce is valid for 24 hours, but can only refresh it when doing a token request => start refreshing after 22 hours
     private static final int NONCE_VALID_SECONDS = 60 * 60 * 22;
-    private static final MessageDigest SHA256; //required to sign ath claim
-
-    static {
+    //MessageDigest is not thread-safe, need one per thread
+    private static final ThreadLocal<MessageDigest> SHA256 = ThreadLocal.withInitial(() -> {
         try {
-            SHA256 = MessageDigest.getInstance("SHA-256");
+            return MessageDigest.getInstance("SHA-256");
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }
-    }
+    });
 
     //if null, means dpop is not enabled yet
     private PrivateJwk<PrivateKey, PublicKey, ?> jwk;
@@ -119,7 +118,7 @@ public class DPoPInterceptor implements ExecChainHandler {
             //already authenticated, need to replace Authorization header prefix and set ath claim
             String token = authorization.getValue().replaceFirst("^Bearer ", "");
             request.setHeader("Authorization", DPOP_HEADER + " " + token);
-            byte[] ath = SHA256.digest(token.getBytes(StandardCharsets.US_ASCII));
+            byte[] ath = SHA256.get().digest(token.getBytes(StandardCharsets.US_ASCII));
             builder.claim("ath", Encoders.BASE64URL.encode(ath));
         } else if (tokenRequest && nonce != null) {
             //still in handshake, need to set nonce


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! A few things to know first:
- For us to be able to merge your PR, you must first fill out a CLA. Information on our CLA process can be found at https://developer.okta.com/cla
- For faster reviews and merging, please fill out all sections of this template completely.
- Your title should be concise and explain what the PR does.
- Follow the single responsibility principal with your PR. This PR should adjust a single set of changes. If it is larger than that, please submit multiple PRs
- Please use this template for your PR, so we can understand the purpose. PR's that do not use this template will be closed.
- Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
- If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->

## Issue(s)
When ApiClient is used concurrently (either with a single or multiple instances) with DPoP enabled, it will eventually fail with an invalid ath DPoP claim error.
This is caused by the static MessageDigest in DPoPInterceptor not being thread safe, and returning invalid token hashes if used from multiple threads.

=> wrap the static field in a ThreadLocal to get an instance per thread.

## Description
<!-- Add a brief description of the issue. Be concise with your summary, but explain what changed. -->

## Category
- [x] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [ ] Library Upgrade
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit or Integration Test(s) 
- [ ] Documentation

## Signoff
- [x] I have submitted a CLA for this PR
- [x] Each commit message explains what the commit does
- [x] I have updated documentation to explain what my PR does
- [x] My code is covered by tests if required
- [x] I did not edit any automatically generated files
