### PR TITLE
Fix #1547: Missing JsonWebKey.setX5c() method in 18.0.0

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.okta.sdk</groupId>
         <artifactId>okta-sdk-root</artifactId>
-        <version>18.0.1-SNAPSHOT</version>
+        <version>19.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-sdk-api</artifactId>

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.okta.sdk</groupId>
         <artifactId>okta-sdk-root</artifactId>
-        <version>18.0.1-SNAPSHOT</version>
+        <version>19.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-sdk-coverage</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.okta.sdk</groupId>
         <artifactId>okta-sdk-root</artifactId>
-        <version>18.0.1-SNAPSHOT</version>
+        <version>19.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-sdk-examples</artifactId>

--- a/examples/quickstart/pom.xml
+++ b/examples/quickstart/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.sdk</groupId>
         <artifactId>okta-sdk-examples</artifactId>
-        <version>18.0.1-SNAPSHOT</version>
+        <version>19.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.okta.sdk</groupId>
         <artifactId>okta-sdk-root</artifactId>
-        <version>18.0.1-SNAPSHOT</version>
+        <version>19.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>okta-sdk-impl</artifactId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.okta.sdk</groupId>
         <artifactId>okta-sdk-root</artifactId>
-        <version>18.0.1-SNAPSHOT</version>
+        <version>19.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>com.okta.sdk</groupId>
     <artifactId>okta-sdk-root</artifactId>
-    <version>18.0.1-SNAPSHOT</version>
+    <version>19.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Okta Java SDK</name>
@@ -68,12 +68,12 @@
             <dependency>
                 <groupId>com.okta.sdk</groupId>
                 <artifactId>okta-sdk-api</artifactId>
-                <version>18.0.1-SNAPSHOT</version>
+                <version>19.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.okta.sdk</groupId>
                 <artifactId>okta-sdk-impl</artifactId>
-                <version>18.0.1-SNAPSHOT</version>
+                <version>19.0.0-SNAPSHOT</version>
             </dependency>
 
             <!-- Other Okta Projects -->
@@ -103,14 +103,14 @@
             <dependency>
                 <groupId>com.okta.sdk</groupId>
                 <artifactId>okta-sdk-integration-tests</artifactId>
-                <version>18.0.1-SNAPSHOT</version>
+                <version>19.0.0-SNAPSHOT</version>
             </dependency>
 
             <!-- Examples -->
             <dependency>
                 <groupId>com.okta.sdk</groupId>
                 <artifactId>okta-sdk-examples-quickstart</artifactId>
-                <version>18.0.1-SNAPSHOT</version>
+                <version>19.0.0-SNAPSHOT</version>
             </dependency>
 
             <!-- Logging -->

--- a/src/swagger/api.yaml
+++ b/src/swagger/api.yaml
@@ -11537,12 +11537,18 @@ paths:
       summary: Create an X.509 Certificate Public Key
       description: Creates a new X.509 certificate credential to the IdP key store.
       operationId: createIdentityProviderKey
-      x-codegen-request-body-name: jsonWebKey
+      x-codegen-request-body-name: x5c
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/JsonWebKey'
+              type: object
+              properties:
+                x5c:
+                  description: X.509 certificate chain that contains a chain of one or more certificates
+                  type: array
+                  items:
+                    type: string
         required: true
       responses:
         '200':


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! A few things to know first:
- For us to be able to merge your PR, you must first fill out a CLA. Information on our CLA process can be found at https://developer.okta.com/cla
- For faster reviews and merging, please fill out all sections of this template completely.
- Your title should be concise and explain what the PR does.
- Follow the single responsibility principal with your PR. This PR should adjust a single set of changes. If it is larger than that, please submit multiple PRs
- Please use this template for your PR, so we can understand the purpose. PR's that do not use this template will be closed.
- Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
- If you have a question about your entire application or use case, please post it on the Okta Developer Forum (https://devforum.okta.com) instead. For urgent issues contact support@okta.com. Issues in this repository are reserved for bug reports and feature requests.
-->

## Issue(s)

#1547 

## Description
<!-- Add a brief description of the issue. Be concise with your summary, but explain what changed. -->

## Category
- [x] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [ ] Library Upgrade
- [ ] Configuration Change
- [ ] Versioning Change
- [ ] Unit or Integration Test(s) 
- [ ] Documentation

## Signoff
- [ ] I have submitted a CLA for this PR
- [ ] Each commit message explains what the commit does
- [ ] I have updated documentation to explain what my PR does
- [ ] My code is covered by tests if required
- [ ] I did not edit any automatically generated files
