### PR TITLE
Scope Handlebars dependencies to OpenAPI generator plugin

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -119,16 +119,6 @@
             <version>${jakarta-annotation.version}</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>com.github.jknack</groupId>
-            <artifactId>handlebars</artifactId>
-            <version>${com.github.jknack.handlebars.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.github.jknack</groupId>
-            <artifactId>handlebars-jackson2</artifactId>
-            <version>4.3.1</version>
-        </dependency>
     </dependencies>
 
     <build>
@@ -169,6 +159,16 @@
                                 <artifactId>httpclient</artifactId>
                             </exclusion>
                         </exclusions>
+                    </dependency>
+                    <dependency>
+                        <groupId>com.github.jknack</groupId>
+                        <artifactId>handlebars</artifactId>
+                        <version>${com.github.jknack.handlebars.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>com.github.jknack</groupId>
+                        <artifactId>handlebars-jackson2</artifactId>
+                        <version>4.3.1</version>
                     </dependency>
                 </dependencies>
                 <executions>


### PR DESCRIPTION
## Issue(s)
N/A

## Description

The version of Handlebars required by this project is only compatible with JDK 17 and upwards; the artifacts built by this project would otherwise be compatible with earlier JDKs. Since the dependency is actually unused by the Okta SDK, the incompatibility with JDK 11 is a bit subtle: it will only manifest in applications that are themselves using Handlebars at runtime.

The SDK's built artifacts do not depend on Handlebars (checked with `jdeps`), nor do any of this project's other dependencies (checked with `coursier resolve`).

## Category
- [ ] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [ ] Library Upgrade
- [ ] Configuration Change
- [x] Versioning Change
- [ ] Unit or Integration Test(s) 
- [ ] Documentation

## Signoff
- [Obvious Fix] I have submitted a CLA for this PR
- [x] Each commit message explains what the commit does
- [ ] I have updated documentation to explain what my PR does
- [ ] My code is covered by tests if required
- [ ] I did not edit any automatically generated files
