### PR TITLE
fix: DomainValidationStatus.FAILED_TO_VERIFY, DevicePostureChecks.include typing, ApplicationGrantsIT CI fix

### DIFF
--- a/api/src/test/java/com/okta/sdk/resource/model/DevicePostureChecksTest.java
+++ b/api/src/test/java/com/okta/sdk/resource/model/DevicePostureChecksTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.sdk.resource.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * OKTA-1221543: DevicePostureChecks.include had no `items` type in the spec, so the generator defaulted
+ * to List&lt;String&gt; while the real API shape is a list of {@code {variableName, value}} pairs. Verifies
+ * it now deserializes into the properly typed DevicePostureCheckMapping.
+ */
+public class DevicePostureChecksTest {
+
+    @Test
+    public void deserialize_includeArray_populatesTypedMappings() throws Exception {
+        String json = "{\"include\":["
+            + "{\"variableName\":\"macOSFirewall\",\"value\":\"1\"},"
+            + "{\"variableName\":\"windowsFirewall\",\"value\":\"1\"}"
+            + "]}";
+
+        DevicePostureChecks checks = new ObjectMapper().readValue(json, DevicePostureChecks.class);
+
+        assertEquals(checks.getInclude().size(), 2);
+        assertEquals(checks.getInclude().get(0).getVariableName(), "macOSFirewall");
+        assertEquals(checks.getInclude().get(0).getValue(), "1");
+        assertEquals(checks.getInclude().get(1).getVariableName(), "windowsFirewall");
+    }
+}

--- a/api/src/test/java/com/okta/sdk/resource/model/DomainValidationStatusTest.java
+++ b/api/src/test/java/com/okta/sdk/resource/model/DomainValidationStatusTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.sdk.resource.model;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+/**
+ * OKTA-1226428: the Okta API returns "validationStatus": "FAILED_TO_VERIFY" in domain responses, but the
+ * SDK enum didn't declare that constant, so it fell through to UNKNOWN_DEFAULT_OPEN_API and the original
+ * value was lost.
+ */
+public class DomainValidationStatusTest {
+
+    @Test
+    public void fromValue_failedToVerify_resolvesToRealConstant() {
+        DomainValidationStatus status = DomainValidationStatus.fromValue("FAILED_TO_VERIFY");
+
+        assertEquals(status, DomainValidationStatus.FAILED_TO_VERIFY);
+        assertNotEquals(status, DomainValidationStatus.UNKNOWN_DEFAULT_OPEN_API);
+        assertEquals(status.getValue(), "FAILED_TO_VERIFY");
+    }
+}

--- a/integration-tests/src/test/groovy/com/okta/sdk/tests/it/ApplicationGrantsIT.groovy
+++ b/integration-tests/src/test/groovy/com/okta/sdk/tests/it/ApplicationGrantsIT.groovy
@@ -437,12 +437,19 @@ class ApplicationGrantsIT extends ITSupport {
             } catch (ApiException e) {
                 exception = e
             }
-            
-            assertThat("Should throw ApiException for non-existent grant", 
+
+            assertThat("Should throw ApiException for non-existent grant",
                 exception, notNullValue())
-            assertThat("Should return 404 for non-existent grant", 
-                exception.getCode(), is(404))
-            
+            if (exception.getCode() == 500 || exception.getCode() == 501) {
+                // Same "OAuth grants not available" acknowledgement as the outer catch below -
+                // getScopeConsentGrant itself can return a transient/feature-unavailable 500/501
+                // instead of a plain ApiException bubbling past this inner try/catch.
+                logger.info("OAuth grants not available: {} - {}", exception.getCode(), exception.getMessage())
+            } else {
+                assertThat("Should return 404 for non-existent grant",
+                    exception.getCode(), is(404))
+            }
+
         } catch (ApiException e) {
             if (e.getCode() == 500 || e.getCode() == 501) {
                 logger.info("OAuth grants not available: {} - {}", e.getCode(), e.getMessage())
@@ -470,12 +477,19 @@ class ApplicationGrantsIT extends ITSupport {
             } catch (ApiException e) {
                 exception = e
             }
-            
-            assertThat("Should throw ApiException for non-existent grant", 
+
+            assertThat("Should throw ApiException for non-existent grant",
                 exception, notNullValue())
-            assertThat("Should return 404 for non-existent grant", 
-                exception.getCode(), is(404))
-            
+            if (exception.getCode() == 500 || exception.getCode() == 501) {
+                // Same "OAuth grants not available" acknowledgement as the outer catch below -
+                // revokeScopeConsentGrant itself can return a transient/feature-unavailable 500/501
+                // instead of a plain ApiException bubbling past this inner try/catch.
+                logger.info("OAuth grants not available: {} - {}", exception.getCode(), exception.getMessage())
+            } else {
+                assertThat("Should return 404 for non-existent grant",
+                    exception.getCode(), is(404))
+            }
+
         } catch (ApiException e) {
             if (e.getCode() == 500 || e.getCode() == 501) {
                 logger.info("OAuth grants not available: {} - {}", e.getCode(), e.getMessage())

--- a/src/swagger/api.yaml
+++ b/src/swagger/api.yaml
@@ -64042,6 +64042,18 @@ components:
           example: macOSFirewall
         _links:
           $ref: '#/components/schemas/LinksSelf'
+    DevicePostureCheckMapping:
+      description: A reference to a Device Posture Check by `variableName` and the value to match against it
+      type: object
+      properties:
+        variableName:
+          type: string
+          description: Unique name of the device posture check
+          example: macOSFirewall
+        value:
+          type: string
+          description: The value to match for this device posture check
+          example: '1'
     DevicePostureChecks:
       x-okta-lifecycle:
         lifecycle: EA
@@ -64053,6 +64065,8 @@ components:
         include:
           type: array
           description: An array of key value pairs including Device Posture Check `variableNames`
+          items:
+            $ref: '#/components/schemas/DevicePostureCheckMapping'
           example:
             - variableName: macOSFirewall
               value: '1'
@@ -64422,6 +64436,7 @@ components:
       type: string
       enum:
         - COMPLETED
+        - FAILED_TO_VERIFY
         - IN_PROGRESS
         - NOT_STARTED
         - VERIFIED


### PR DESCRIPTION
## Issue(s)

- OKTA-1226428 - `DomainValidationStatus` missing `FAILED_TO_VERIFY` enum constant
- OKTA-1221543 - `DevicePostureChecks.include` typed `List<String>` instead of a proper structured type

## Description

### 1. `DomainValidationStatus` missing `FAILED_TO_VERIFY` (P0)

The Okta API returns `"validationStatus": "FAILED_TO_VERIFY"` in domain responses (e.g. `GET /api/v1/domains/{domainId}`), but the SDK enum only declared `COMPLETED`, `IN_PROGRESS`, `NOT_STARTED`, `VERIFIED`. Jackson deserialization fell through to `UNKNOWN_DEFAULT_OPEN_API` via `READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE`, silently losing the original value. Added the missing constant to `src/swagger/api.yaml`.

### 2. `DevicePostureChecks.include` typed as `List<String>` (P0)

`DevicePostureChecks.include` had no `items` type in the spec - just an `example` - so the generator defaulted to `List<String>`, while the real API shape is a list of `{variableName, value}` pairs. Added a new `DevicePostureCheckMapping` schema and typed `include` as `List<DevicePostureCheckMapping>`.

### 3. CI fix: `ApplicationGrantsIT` non-existent-grant tests

Observed on `master` post-merge (unrelated to #1699's actual changes - a pre-existing latent test bug that CI happened to hit): `testGetNonExistentGrantError`/`testRevokeNonExistentGrantError` already acknowledge a `500`/`501` response as "OAuth grants not available" via an *outer* catch block, but that only covers exceptions thrown outside the inner try/catch. When `getScopeConsentGrant`/`revokeScopeConsentGrant` themselves returned `500`, the exception was caught into the local `exception` variable and then failed the "should return 404" assertion instead of being recognized as the same acknowledged case. Applied the same 500/501 check to that inner exception in both tests.

## Category
- [x] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [ ] Library Upgrade
- [ ] Configuration Change
- [ ] Versioning Change
- [x] Unit or Integration Test(s)
- [ ] Documentation

## Signoff
- [ ] I have submitted a CLA for this PR (N/A - internal Okta contributor)
- [x] Each commit message explains what the commit does
- [ ] I have updated documentation to explain what my PR does
- [x] My code is covered by tests if required
- [x] I did not edit any automatically generated files

