### PR TITLE
fix: disable broken polymorphic resolution on 6 more discriminator schemas (GH issues deep-dive)

### DIFF
--- a/api/src/main/resources/custom_templates/ApiClient.mustache
+++ b/api/src/main/resources/custom_templates/ApiClient.mustache
@@ -238,9 +238,19 @@ protected List<ServerConfiguration> servers = new ArrayList<ServerConfiguration>
             objectMapper.enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
 
             // OKTA-1227472: disable broken polymorphic type resolution on models whose spec-declared
-            // discriminator subtypes don't actually extend them.
+            // discriminator subtypes don't actually extend them. Found via an audit of every
+            // oneOf/anyOf + discriminator pair in the spec for this same defect class - these six
+            // have the identical problem (ListJwk200ResponseInner/SamlAttributeStatement above were
+            // the first two found; OrgContactTypeObj in particular breaks the real, commonly-used
+            // listOrgContactTypes endpoint).
             objectMapper.addMixIn(com.okta.sdk.resource.model.ListJwk200ResponseInner.class, NoPolymorphicTypeInfoMixin.class);
             objectMapper.addMixIn(com.okta.sdk.resource.model.SamlAttributeStatement.class, NoPolymorphicTypeInfoMixin.class);
+            objectMapper.addMixIn(com.okta.sdk.resource.model.AgentJsonSigningKeyRequest.class, NoPolymorphicTypeInfoMixin.class);
+            objectMapper.addMixIn(com.okta.sdk.resource.model.AgentJsonSigningKeyResponse.class, NoPolymorphicTypeInfoMixin.class);
+            objectMapper.addMixIn(com.okta.sdk.resource.model.ManagedConnection.class, NoPolymorphicTypeInfoMixin.class);
+            objectMapper.addMixIn(com.okta.sdk.resource.model.ManagedConnectionCreatable.class, NoPolymorphicTypeInfoMixin.class);
+            objectMapper.addMixIn(com.okta.sdk.resource.model.OrgContactTypeObj.class, NoPolymorphicTypeInfoMixin.class);
+            objectMapper.addMixIn(com.okta.sdk.resource.model.PotentialConnection.class, NoPolymorphicTypeInfoMixin.class);
 
             // OKTA-1218351: restore NON_NULL serialization on Application and its subtypes, overriding the
             // per-property JsonInclude(ALWAYS) generated for their required properties.

--- a/api/src/test/java/com/okta/sdk/resource/client/ApiClientJacksonMixinTest.java
+++ b/api/src/test/java/com/okta/sdk/resource/client/ApiClientJacksonMixinTest.java
@@ -19,13 +19,18 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.okta.sdk.cache.Cache;
 import com.okta.sdk.cache.CacheManager;
+import com.okta.sdk.resource.model.AgentJsonSigningKeyRequest;
+import com.okta.sdk.resource.model.AgentJsonSigningKeyResponse;
 import com.okta.sdk.resource.model.Application;
 import com.okta.sdk.resource.model.ApplicationVisibility;
 import com.okta.sdk.resource.model.ApplicationVisibilityHide;
 import com.okta.sdk.resource.model.ListJwk200ResponseInner;
+import com.okta.sdk.resource.model.ManagedConnection;
+import com.okta.sdk.resource.model.ManagedConnectionCreatable;
 import com.okta.sdk.resource.model.OpenIdConnectApplication;
 import com.okta.sdk.resource.model.OrgContactType;
 import com.okta.sdk.resource.model.OrgContactTypeObj;
+import com.okta.sdk.resource.model.PotentialConnection;
 import com.okta.sdk.resource.model.SamlApplication;
 import com.okta.sdk.resource.model.SamlAttributeStatement;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
@@ -189,5 +194,106 @@ public class ApiClientJacksonMixinTest {
         assertEquals(contacts.size(), 2);
         assertEquals(contacts.get(0).getContactType(), OrgContactType.BILLING);
         assertEquals(contacts.get(1).getContactType(), OrgContactType.TECHNICAL);
+    }
+
+    /**
+     * Same audit finding as OrgContactTypeObj: AgentJsonSigningKeyRequest declares RSA/EC subtypes that
+     * don't extend it. Currently unreferenced by any operation in the spec, fixed for consistency.
+     */
+    @Test
+    public void deserializeAgentJsonSigningKeyRequest_withRsaAndEcEntries_doesNotThrow() throws Exception {
+        String json = "["
+            + "{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"mkC6\",\"use\":\"sig\",\"alg\":\"RS256\"},"
+            + "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"abc\",\"y\":\"def\",\"use\":\"sig\",\"alg\":\"ES256\"}"
+            + "]";
+
+        List<AgentJsonSigningKeyRequest> keys = objectMapper.readValue(json,
+            new TypeReference<List<AgentJsonSigningKeyRequest>>() { });
+
+        assertEquals(keys.size(), 2);
+        assertEquals(keys.get(0).getE(), "AQAB");
+        assertEquals(keys.get(1).getCrv().getValue(), "P-256");
+    }
+
+    /**
+     * Same audit finding, response-side counterpart of AgentJsonSigningKeyRequest.
+     */
+    @Test
+    public void deserializeAgentJsonSigningKeyResponse_withRsaAndEcEntries_doesNotThrow() throws Exception {
+        String json = "["
+            + "{\"kty\":\"RSA\",\"e\":\"AQAB\",\"n\":\"mkC6\",\"use\":\"sig\",\"alg\":\"RS256\",\"id\":\"key1\"},"
+            + "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"abc\",\"y\":\"def\",\"use\":\"sig\",\"alg\":\"ES256\",\"id\":\"key2\"}"
+            + "]";
+
+        List<AgentJsonSigningKeyResponse> keys = objectMapper.readValue(json,
+            new TypeReference<List<AgentJsonSigningKeyResponse>>() { });
+
+        assertEquals(keys.size(), 2);
+        assertEquals(keys.get(0).getId(), "key1");
+        assertEquals(keys.get(1).getCrv().getValue(), "P-256");
+    }
+
+    /**
+     * Same audit finding: ManagedConnection declares 4 connectionType subtypes that don't extend it.
+     * Reachable from the managed-connection-list endpoint.
+     *
+     * Separate, pre-existing quirk unrelated to this fix: each oneOf branch declares its own
+     * single-value connectionType enum (e.g. just "IDENTITY_ASSERTION_APP_INSTANCE"), and the flat
+     * merged class ends up keeping only the last-merged branch's enum ("STS_SERVICE_ACCOUNT") - every
+     * other value falls back to UNKNOWN_DEFAULT_OPEN_API (harmless, since
+     * READ_UNKNOWN_ENUM_VALUES_AS_NULL-style fallback is already relied on elsewhere; it doesn't throw).
+     * This test only asserts the polymorphism fix - that deserialization doesn't throw - not full type
+     * fidelity, which is a separate, wider issue with how the generator merges oneOf enum properties.
+     */
+    @Test
+    public void deserializeManagedConnection_withDifferentConnectionTypes_doesNotThrow() throws Exception {
+        String json = "["
+            + "{\"connectionType\":\"IDENTITY_ASSERTION_APP_INSTANCE\",\"id\":\"conn1\"},"
+            + "{\"connectionType\":\"STS_SERVICE_ACCOUNT\",\"id\":\"conn2\"}"
+            + "]";
+
+        List<ManagedConnection> connections = objectMapper.readValue(json,
+            new TypeReference<List<ManagedConnection>>() { });
+
+        assertEquals(connections.size(), 2);
+        assertEquals(connections.get(0).getId(), "conn1");
+        assertEquals(connections.get(1).getConnectionType(), ManagedConnection.ConnectionTypeEnum.STS_SERVICE_ACCOUNT);
+    }
+
+    /**
+     * Same audit finding, "creatable" (request-body) counterpart of ManagedConnection. See the enum
+     * fidelity caveat on {@link #deserializeManagedConnection_withDifferentConnectionTypes_doesNotThrow}.
+     */
+    @Test
+    public void deserializeManagedConnectionCreatable_withDifferentConnectionTypes_doesNotThrow() throws Exception {
+        String json = "["
+            + "{\"connectionType\":\"IDENTITY_ASSERTION_CUSTOM_AS\"},"
+            + "{\"connectionType\":\"STS_SERVICE_ACCOUNT\"}"
+            + "]";
+
+        List<ManagedConnectionCreatable> connections = objectMapper.readValue(json,
+            new TypeReference<List<ManagedConnectionCreatable>>() { });
+
+        assertEquals(connections.size(), 2);
+        assertEquals(connections.get(1).getConnectionType(), ManagedConnectionCreatable.ConnectionTypeEnum.STS_SERVICE_ACCOUNT);
+    }
+
+    /**
+     * Same audit finding: PotentialConnection is a near-duplicate of ManagedConnection with the identical
+     * defect (same 4 subtypes, same discriminator). See the enum fidelity caveat on
+     * {@link #deserializeManagedConnection_withDifferentConnectionTypes_doesNotThrow}.
+     */
+    @Test
+    public void deserializePotentialConnection_withDifferentConnectionTypes_doesNotThrow() throws Exception {
+        String json = "["
+            + "{\"connectionType\":\"IDENTITY_ASSERTION_APP_INSTANCE\"},"
+            + "{\"connectionType\":\"STS_SERVICE_ACCOUNT\"}"
+            + "]";
+
+        List<PotentialConnection> connections = objectMapper.readValue(json,
+            new TypeReference<List<PotentialConnection>>() { });
+
+        assertEquals(connections.size(), 2);
+        assertEquals(connections.get(1).getConnectionType(), PotentialConnection.ConnectionTypeEnum.STS_SERVICE_ACCOUNT);
     }
 }

--- a/api/src/test/java/com/okta/sdk/resource/client/ApiClientJacksonMixinTest.java
+++ b/api/src/test/java/com/okta/sdk/resource/client/ApiClientJacksonMixinTest.java
@@ -19,10 +19,14 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.okta.sdk.cache.Cache;
 import com.okta.sdk.cache.CacheManager;
+import com.okta.sdk.resource.model.Application;
 import com.okta.sdk.resource.model.ApplicationVisibility;
 import com.okta.sdk.resource.model.ApplicationVisibilityHide;
 import com.okta.sdk.resource.model.ListJwk200ResponseInner;
 import com.okta.sdk.resource.model.OpenIdConnectApplication;
+import com.okta.sdk.resource.model.OrgContactType;
+import com.okta.sdk.resource.model.OrgContactTypeObj;
+import com.okta.sdk.resource.model.SamlApplication;
 import com.okta.sdk.resource.model.SamlAttributeStatement;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.testng.annotations.Test;
@@ -134,5 +138,56 @@ public class ApiClientJacksonMixinTest {
 
         assertNotNull(json);
         assertTrue(json.contains("\"name\""), "name should be present when set, got: " + json);
+    }
+
+    /**
+     * GH-1654: reported that listApplications only returned OIDC apps, no SAML apps. A SAML app whose
+     * settings.signOn.attributeStatements uses the (now-fixed) broken SamlAttributeStatement type would
+     * throw InvalidTypeIdException while parsing the response array - depending on how a caller's
+     * pagination/error handling reacted to that, it could plausibly look like SAML apps were being
+     * silently dropped. Confirms a mixed OIDC/SAML list - with attribute statements populated - now
+     * deserializes cleanly end-to-end via Application's own (structurally correct) polymorphism.
+     */
+    @Test
+    public void deserializeApplicationList_withMixedOidcAndSamlAttributeStatements_doesNotThrow() throws Exception {
+        String json = "["
+            + "{\"signOnMode\":\"OPENID_CONNECT\",\"label\":\"oidc-app\",\"id\":\"0oa1\"},"
+            + "{\"signOnMode\":\"SAML_2_0\",\"label\":\"saml-app\",\"id\":\"0oa2\",\"settings\":{\"signOn\":{"
+            + "\"attributeStatements\":["
+            + "{\"type\":\"EXPRESSION\",\"name\":\"email\",\"values\":[\"user.email\"]},"
+            + "{\"type\":\"GROUP\",\"filterType\":\"STARTS_WITH\",\"filterValue\":\"Team\"}"
+            + "]}}}"
+            + "]";
+
+        List<Application> apps = objectMapper.readValue(json, new TypeReference<List<Application>>() { });
+
+        assertEquals(apps.size(), 2);
+        assertTrue(apps.get(0) instanceof OpenIdConnectApplication, "expected OpenIdConnectApplication, got " + apps.get(0).getClass());
+        assertTrue(apps.get(1) instanceof SamlApplication, "expected SamlApplication, got " + apps.get(1).getClass());
+
+        SamlApplication samlApp = (SamlApplication) apps.get(1);
+        List<SamlAttributeStatement> statements = samlApp.getSettings().getSignOn().getAttributeStatements();
+        assertEquals(statements.size(), 2);
+        assertEquals(statements.get(0).getType(), SamlAttributeStatement.TypeEnum.EXPRESSION);
+        assertEquals(statements.get(1).getType(), SamlAttributeStatement.TypeEnum.GROUP);
+    }
+
+    /**
+     * Found via an audit of every oneOf/anyOf + discriminator pair in the spec for the same defect class
+     * as OKTA-1227472: OrgContactTypeObj declares BILLING/TECHNICAL subtypes that don't extend it, breaking
+     * the real listOrgContactTypes endpoint.
+     */
+    @Test
+    public void deserializeOrgContactTypeObj_withBillingAndTechnicalEntries_doesNotThrow() throws Exception {
+        String json = "["
+            + "{\"contactType\":\"BILLING\"},"
+            + "{\"contactType\":\"TECHNICAL\"}"
+            + "]";
+
+        List<OrgContactTypeObj> contacts = objectMapper.readValue(json, new TypeReference<List<OrgContactTypeObj>>() { });
+
+        assertEquals(contacts.size(), 2);
+        assertEquals(contacts.get(0).getContactType(), OrgContactType.BILLING);
+        assertEquals(contacts.get(1).getContactType(), OrgContactType.TECHNICAL);
     }
 }


### PR DESCRIPTION
## Issue(s)

Deep-dive triage of the remaining open GitHub issues (https://github.com/okta/okta-sdk-java/issues):

- Related to #1654 - List apps only brings OIDC apps
- Related to #1693 - IdentityProvider round-trip silently drops/invents/mutates protocol fields (already fixed on `master` via #1695/#1699 - see below)
- Related to #1664 - Keep client-side pagination in future releases (already satisfied on `master` - see below)

## Description

### Triage summary

**#1693** - Already fixed on `master` (PR #1695 added the missing discriminator to `IdentityProviderProtocol`, and #1699 shipped further Jackson polymorphism fixes). Verified `IdentityProviderProtocolDeserializerTest`'s 14 regression tests (SAML2/OIDC/OAuth2/MTLS round-trips) all pass on current `master`. No code change needed in this PR; the issue just needs to be closed once released.

**#1664** - Already satisfied. The deprecated `PaginationUtil`/`ApiClient#getResponseHeaders()`/`getAfter()` methods are still present and functional (`PaginationUtilTest` passes), so the pre-25.0.0 "pass `after` yourself" workflow continues to work. No removal has happened; nothing to fix.

**#1654** - No SAML-specific filtering exists anywhere in the SDK's `listApplications` path (`ApplicationApi.listApplications` is a plain generated call; `Application`'s own `@JsonSubTypes` correctly maps `SAML_2_0` -> `SamlApplication` via real Java inheritance). However, auditing the spec for the same defect class fixed in OKTA-1227472/#1699 (`ListJwk200ResponseInner`/`SamlAttributeStatement`: `oneOf`/`anyOf` + `discriminator` without `allOf`-based inheritance, causing Jackson's `@JsonSubTypes` to throw `InvalidTypeIdException`) turned up a very plausible mechanism: before that fix shipped, a SAML app with `settings.signOn.attributeStatements` populated would throw while being parsed as part of a `listApplications` response array. Depending on how a caller's error/pagination handling reacted to that exception, this could plausibly present as "SAML apps silently missing, only OIDC returned." Added a regression test (`deserializeApplicationList_withMixedOidcAndSamlAttributeStatements_doesNotThrow`) confirming a mixed OIDC/SAML list with attribute statements now deserializes cleanly. This is very likely already fixed as a side effect of #1699 - will comment on the issue asking the reporter to confirm on the latest release.

### Bonus finding: 6 more instances of the same discriminator defect

Since OKTA-1227472 and #1693/#1695 were both "a `oneOf`/`anyOf` + `discriminator` pair whose subtypes don't actually extend the base via `allOf`," I audited every such pair in `src/swagger/api.yaml` for the same pattern. Found and fixed 6 more:

- `AgentJsonSigningKeyRequest` / `AgentJsonSigningKeyResponse` (currently unreferenced by any operation in the spec, fixed for correctness/consistency anyway)
- `ManagedConnection` / `ManagedConnectionCreatable` (reachable from managed-connection list endpoints)
- `PotentialConnection` (reachable from potential-connection list endpoints)
- `OrgContactTypeObj` - **this one is live and reachable from the real, commonly-used `listOrgContactTypes` endpoint** - any caller of that endpoint would hit `InvalidTypeIdException` today

Fixed the same way as the existing `ListJwk200ResponseInner`/`SamlAttributeStatement` mixins: `@JsonTypeInfo(use = Id.NONE)` registered on `ApiClient`'s default `ObjectMapper`, disabling the broken polymorphic resolution. Added a regression test for `OrgContactTypeObj` (BILLING/TECHNICAL) confirming it no longer throws.

(Note: `GroupProfile` also has this same `oneOf`/`discriminator` pattern, but it's inert in practice - `GroupProfileDeserializer` is a hand-written custom deserializer that bypasses Jackson's annotation-based polymorphism entirely, so it was excluded from this fix as unnecessary.)

## Category
- [x] Bugfix
- [ ] Enhancement
- [ ] New Feature
- [ ] Library Upgrade
- [ ] Configuration Change
- [ ] Versioning Change
- [x] Unit or Integration Test(s)
- [ ] Documentation

## Signoff
- [ ] I have submitted a CLA for this PR (N/A - internal Okta contributor)
- [x] Each commit message explains what the commit does
- [ ] I have updated documentation to explain what my PR does
- [x] My code is covered by tests if required
- [x] I did not edit any automatically generated files
