### PR TITLE
fix: bump jackson-databind and httpclient5 to resolve NVD-flagged CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,11 +34,11 @@
     <inceptionYear>2017</inceptionYear>
 
     <properties>
-        <jackson.version>2.18.2</jackson.version>
+        <jackson.version>2.18.9</jackson.version>
         <snakeyaml.version>2.4</snakeyaml.version>
         <bouncycastle.version>1.84</bouncycastle.version>
         <jjwt.version>0.12.6</jjwt.version>
-        <org.apache.httpcomponents.client5.version>5.5.1</org.apache.httpcomponents.client5.version>
+        <org.apache.httpcomponents.client5.version>5.6.2</org.apache.httpcomponents.client5.version>
         <okta.sdk.previousVersion>24.0.1</okta.sdk.previousVersion>
         <okta.commons.version>2.0.1</okta.commons.version>
         <com.google.auto.service.version>1.1.1</com.google.auto.service.version>


### PR DESCRIPTION
## Summary
- Bump `jackson.version` 2.18.2 -> 2.18.9, fixing CVE-2026-54512, CVE-2026-54513, CVE-2026-54514, CVE-2026-54515 (polymorphic deserialization bypasses, SSRF via eager DNS resolution in `InetSocketAddress` handling).
- Bump `org.apache.httpcomponents.client5.version` 5.5.1 -> 5.6.2, which pulls in `httpcore5` 5.4.3, fixing CVE-2026-54399 and CVE-2026-54428 (HTTP/1.1 parser and HTTP/2 HPACK decoder resource-exhaustion DoS).
- These were surfacing as `dependency-check:aggregate` build failures during release prep (CVSS >= 0.0 threshold).

## Test plan
- [x] `mvn dependency:tree` confirms `httpcore5` resolves to 5.4.3 and `jackson-databind` resolves to 2.18.9
- [x] `mvn org.owasp:dependency-check-maven:12.1.0:aggregate` passes with BUILD SUCCESS and no flagged CVEs