### PR TITLE
Fix Application partial updates, enum case-insensitivity, and test execution

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -227,6 +227,7 @@
                                 <sourceFolder>src/gen/java/main</sourceFolder>
                                 <useRuntimeException>true</useRuntimeException>
                                 <enumUnknownDefaultCase>true</enumUnknownDefaultCase>
+                                <useEnumCaseInsensitive>true</useEnumCaseInsensitive>
                                 <useJakartaEe>true</useJakartaEe>
                             </configOptions>
                             <additionalProperties>serializableModel=true</additionalProperties>

--- a/api/src/main/java/com/okta/sdk/resource/application/PartialApplicationUpdater.java
+++ b/api/src/main/java/com/okta/sdk/resource/application/PartialApplicationUpdater.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.sdk.resource.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.okta.commons.lang.Assert;
+import com.okta.sdk.resource.api.ApplicationApi;
+import com.okta.sdk.resource.client.ApiClient;
+import com.okta.sdk.resource.client.ApiException;
+import com.okta.sdk.resource.model.Application;
+
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Helper for updating an {@link Application} when the caller only has a subset of its properties to
+ * change (OKTA-1228269).
+ *
+ * <p>The Admin Management API's {@code PUT /api/v1/apps/{appId}} (backing
+ * {@link ApplicationApi#replaceApplication}) is a full-replace endpoint - the spec requires every required
+ * property on every call, and there is no {@code PATCH} operation for applications. Sending a partial
+ * {@link Application} (or subtype, e.g. {@code OpenIdConnectApplication}) directly to
+ * {@code replaceApplication} is rejected with a {@code 400}, because the server can't validate or resolve
+ * the application's concrete type from an incomplete body.
+ *
+ * <p>This helper works around that by fetching the current application, overlaying only the properties
+ * set on the caller's partial object, and replacing with the merged, fully-populated result - giving
+ * callers effective partial-update semantics without violating the API's full-replace contract.
+ *
+ * <p>Because the overlay only applies properties that are set (non-null) on {@code partialApplication},
+ * this is a merge, not a JSON Merge Patch: explicitly setting a property to {@code null} does not clear
+ * it on the existing application. Call {@link ApplicationApi#replaceApplication} directly with a
+ * fully-populated object to clear a property.
+ *
+ * <p>{@code partialApplication} must be the same concrete subtype as the application being updated (e.g.
+ * both {@code OpenIdConnectApplication}) - merging across subtypes would blend fields from incompatible
+ * application types, so it's rejected up front rather than producing a confusing server-side error.
+ *
+ * @since 25.0.5
+ */
+public final class PartialApplicationUpdater {
+
+    private PartialApplicationUpdater() {
+    }
+
+    /**
+     * Fetches the application identified by {@code appId}, overlays the properties set on
+     * {@code partialApplication} onto it, and replaces the application with the merged result.
+     *
+     * @param apiClient the {@link ApiClient} to use for the underlying get/replace calls
+     * @param appId the {@code id} of the application to update
+     * @param partialApplication an {@link Application} (or subtype) with only the changed properties set
+     * @return the updated {@link Application} as returned by the API
+     * @throws ApiException if the underlying get or replace call fails
+     */
+    public static Application partialUpdateApplication(ApiClient apiClient, String appId,
+            Application partialApplication) throws ApiException {
+
+        Assert.notNull(apiClient, "apiClient cannot be null");
+        Assert.hasText(appId, "appId cannot be null or empty");
+        Assert.notNull(partialApplication, "partialApplication cannot be null");
+
+        ApplicationApi applicationApi = new ApplicationApi(apiClient);
+        Application existingApplication = applicationApi.getApplication(appId, null);
+        Application mergedApplication = mergeApplication(apiClient.getObjectMapper(), existingApplication, partialApplication);
+
+        return applicationApi.replaceApplication(appId, mergedApplication);
+    }
+
+    /**
+     * Overlays the properties set on {@code partialApplication} onto {@code existingApplication}, returning
+     * a new, fully-populated {@link Application} suitable for {@link ApplicationApi#replaceApplication}.
+     *
+     * <p>Exposed separately from {@link #partialUpdateApplication} so the merge itself can be exercised
+     * without a live {@link ApiClient}.
+     *
+     * @param objectMapper the {@link ObjectMapper} to serialize/merge/deserialize with - use
+     *                      {@link ApiClient#getObjectMapper()} so the same Application-subtype
+     *                      null-omission and polymorphism behavior applies
+     * @param existingApplication the current, fully-populated application
+     * @param partialApplication an {@link Application} (or subtype) with only the changed properties set
+     * @return the merged, fully-populated {@link Application}
+     */
+    public static Application mergeApplication(ObjectMapper objectMapper, Application existingApplication,
+            Application partialApplication) {
+
+        Assert.notNull(objectMapper, "objectMapper cannot be null");
+        Assert.notNull(existingApplication, "existingApplication cannot be null");
+        Assert.notNull(partialApplication, "partialApplication cannot be null");
+        Assert.isTrue(partialApplication.getClass().equals(existingApplication.getClass()),
+            "partialApplication must be the same concrete type as existingApplication (expected "
+                + existingApplication.getClass().getSimpleName() + ", got "
+                + partialApplication.getClass().getSimpleName() + ")");
+
+        // existingNode retains read-only fields (id, created, lastUpdated, _links) from the fetched
+        // application; replaceApplication tolerates receiving them back unchanged.
+        JsonNode existingNode = objectMapper.valueToTree(existingApplication);
+        JsonNode partialNode = objectMapper.valueToTree(partialApplication);
+        JsonNode mergedNode = deepMerge(existingNode, partialNode);
+
+        try {
+            return objectMapper.treeToValue(mergedNode, Application.class);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to merge partial application update", e);
+        }
+    }
+
+    private static JsonNode deepMerge(JsonNode base, JsonNode overlay) {
+        if (!(base instanceof ObjectNode) || !(overlay instanceof ObjectNode)) {
+            return overlay;
+        }
+
+        ObjectNode merged = ((ObjectNode) base).deepCopy();
+        Iterator<Map.Entry<String, JsonNode>> overlayFields = overlay.fields();
+        while (overlayFields.hasNext()) {
+            Map.Entry<String, JsonNode> field = overlayFields.next();
+            JsonNode baseValue = merged.get(field.getKey());
+            JsonNode overlayValue = field.getValue();
+            if (baseValue != null && baseValue.isObject() && overlayValue.isObject()) {
+                merged.set(field.getKey(), deepMerge(baseValue, overlayValue));
+            } else {
+                merged.set(field.getKey(), overlayValue);
+            }
+        }
+        return merged;
+    }
+}

--- a/api/src/test/java/com/okta/sdk/resource/application/PartialApplicationUpdaterTest.java
+++ b/api/src/test/java/com/okta/sdk/resource/application/PartialApplicationUpdaterTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2026-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.sdk.resource.application;
+
+import com.okta.sdk.cache.Cache;
+import com.okta.sdk.cache.CacheManager;
+import com.okta.sdk.resource.client.ApiClient;
+import com.okta.sdk.resource.model.Application;
+import com.okta.sdk.resource.model.ApplicationCredentialsOAuthClient;
+import com.okta.sdk.resource.model.ApplicationSignOnMode;
+import com.okta.sdk.resource.model.ApplicationVisibility;
+import com.okta.sdk.resource.model.OAuthApplicationCredentials;
+import com.okta.sdk.resource.model.OpenIdConnectApplication;
+import com.okta.sdk.resource.model.OpenIdConnectApplicationSettings;
+import com.okta.sdk.resource.model.OpenIdConnectApplicationSettingsClient;
+import com.okta.sdk.resource.model.SamlApplication;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link PartialApplicationUpdater}, exercising the exact partial-update scenarios
+ * reported live against the Admin Management API in OKTA-1228269: omitting {@code name} and/or
+ * {@code credentials} from an {@code OpenIdConnectApplication} PUT gets rejected by the server with
+ * misleading {@code 400}s (missing app settings / invalid signOnMode), because those are required,
+ * ALWAYS-serialized sibling fields on a polymorphic subtype. These tests verify the merge step - not a
+ * live API call - so they only need to prove the merged body is always fully populated with the
+ * existing application's required fields, regardless of what the caller's partial object omits.
+ */
+public class PartialApplicationUpdaterTest {
+
+    // A minimal no-op CacheManager, so this test doesn't need the okta-sdk-impl module (which would
+    // introduce a circular dependency back onto this api module) just to construct an ApiClient.
+    private static final CacheManager NOOP_CACHE_MANAGER = new CacheManager() {
+        @Override
+        public <K, V> Cache<K, V> getCache(String name) {
+            return new Cache<K, V>() {
+                @Override
+                public V get(K key) {
+                    return null;
+                }
+
+                @Override
+                public V put(K key, V value) {
+                    return null;
+                }
+
+                @Override
+                public V remove(K key) {
+                    return null;
+                }
+            };
+        }
+    };
+
+    private final ApiClient apiClient = new ApiClient(HttpClients.createDefault(), NOOP_CACHE_MANAGER);
+
+    private static OpenIdConnectApplication fullyPopulatedExistingApp() {
+        OpenIdConnectApplication app = new OpenIdConnectApplication();
+        app.setLabel("partial-update-test");
+        app.setSignOnMode(ApplicationSignOnMode.OPENID_CONNECT);
+        app.setName(OpenIdConnectApplication.NameEnum.OIDC_CLIENT);
+        app.setVisibility(new ApplicationVisibility().autoSubmitToolbar(true));
+
+        OAuthApplicationCredentials credentials = new OAuthApplicationCredentials()
+            .oauthClient(new ApplicationCredentialsOAuthClient()
+                .clientId("existing-client-id")
+                .autoKeyRotation(true));
+        app.setCredentials(credentials);
+
+        OpenIdConnectApplicationSettingsClient oauthClient = new OpenIdConnectApplicationSettingsClient()
+            .redirectUris(List.of("https://example.com/callback"))
+            .clientUri("https://example.com");
+        app.setSettings(new OpenIdConnectApplicationSettings().oauthClient(oauthClient));
+
+        return app;
+    }
+
+    /**
+     * Agrja Rastogi's first repro on OKTA-1228269: a partial update that sets only settings fields,
+     * omitting both {@code name} and {@code credentials} entirely, produced a {@code 400} ("Invalid
+     * signOnMode; settings.signOn doesn't match type; Missing visibility") because the server couldn't
+     * resolve the OIDC subtype without them. The merge must restore both from the existing application.
+     */
+    @Test
+    public void mergeApplication_partialOmittingNameAndCredentials_restoresBothFromExisting() throws Exception {
+        OpenIdConnectApplication existing = fullyPopulatedExistingApp();
+
+        OpenIdConnectApplication partial = new OpenIdConnectApplication();
+        partial.setSettings(new OpenIdConnectApplicationSettings()
+            .oauthClient(new OpenIdConnectApplicationSettingsClient()
+                .redirectUris(List.of("https://example.com/new-callback"))));
+
+        Application merged = PartialApplicationUpdater.mergeApplication(
+            apiClient.getObjectMapper(), existing, partial);
+
+        assertTrue(merged instanceof OpenIdConnectApplication, "expected OpenIdConnectApplication, got " + merged.getClass());
+        OpenIdConnectApplication mergedOidc = (OpenIdConnectApplication) merged;
+
+        assertEquals(mergedOidc.getName(), OpenIdConnectApplication.NameEnum.OIDC_CLIENT);
+        assertEquals(mergedOidc.getCredentials().getOauthClient().getClientId(), "existing-client-id");
+    }
+
+    /**
+     * Agrja's second repro: omitting {@code credentials} alone (with {@code name} correct) produced a
+     * {@code 400} ("Missing app settings") referencing a field irrelevant to OIDC apps. The merge must
+     * restore credentials from the existing application while still applying the caller's settings change.
+     */
+    @Test
+    public void mergeApplication_partialOmittingCredentialsOnly_restoresCredentialsAndAppliesSettingsChange() throws Exception {
+        OpenIdConnectApplication existing = fullyPopulatedExistingApp();
+
+        OpenIdConnectApplication partial = new OpenIdConnectApplication();
+        partial.setName(OpenIdConnectApplication.NameEnum.OIDC_CLIENT);
+        partial.setSettings(new OpenIdConnectApplicationSettings()
+            .oauthClient(new OpenIdConnectApplicationSettingsClient()
+                .redirectUris(List.of("https://example.com/new-callback"))));
+
+        Application merged = PartialApplicationUpdater.mergeApplication(
+            apiClient.getObjectMapper(), existing, partial);
+
+        OpenIdConnectApplication mergedOidc = (OpenIdConnectApplication) merged;
+        assertEquals(mergedOidc.getCredentials().getOauthClient().getClientId(), "existing-client-id");
+        assertEquals(mergedOidc.getSettings().getOauthClient().getRedirectUris(), List.of("https://example.com/new-callback"));
+    }
+
+    /**
+     * The merge must be a deep merge of nested objects, not a full replace of {@code settings.oauthClient}:
+     * changing only {@code redirectUris} must not drop sibling settings fields (e.g. {@code clientUri})
+     * that the caller's partial object never touched.
+     */
+    @Test
+    public void mergeApplication_partialSettingsChange_preservesUntouchedSiblingSettingsFields() throws Exception {
+        OpenIdConnectApplication existing = fullyPopulatedExistingApp();
+
+        OpenIdConnectApplication partial = new OpenIdConnectApplication();
+        partial.setSettings(new OpenIdConnectApplicationSettings()
+            .oauthClient(new OpenIdConnectApplicationSettingsClient()
+                .redirectUris(List.of("https://example.com/new-callback"))));
+
+        Application merged = PartialApplicationUpdater.mergeApplication(
+            apiClient.getObjectMapper(), existing, partial);
+
+        OpenIdConnectApplicationSettingsClient mergedOauthClient =
+            ((OpenIdConnectApplication) merged).getSettings().getOauthClient();
+        assertEquals(mergedOauthClient.getRedirectUris(), List.of("https://example.com/new-callback"));
+        assertEquals(mergedOauthClient.getClientUri(), "https://example.com", "untouched sibling field should survive the merge");
+    }
+
+    /**
+     * A true no-op-on-everything-else partial update (only {@code label} changed) must preserve every
+     * other required field untouched - the simplest, most common partial-update case.
+     */
+    @Test
+    public void mergeApplication_labelOnlyChange_preservesEverythingElse() throws Exception {
+        OpenIdConnectApplication existing = fullyPopulatedExistingApp();
+
+        OpenIdConnectApplication partial = new OpenIdConnectApplication();
+        partial.setLabel("renamed-app");
+
+        Application merged = PartialApplicationUpdater.mergeApplication(
+            apiClient.getObjectMapper(), existing, partial);
+
+        assertEquals(merged.getLabel(), "renamed-app");
+        OpenIdConnectApplication mergedOidc = (OpenIdConnectApplication) merged;
+        assertEquals(mergedOidc.getName(), OpenIdConnectApplication.NameEnum.OIDC_CLIENT);
+        assertEquals(mergedOidc.getCredentials().getOauthClient().getClientId(), "existing-client-id");
+        assertEquals(mergedOidc.getSettings().getOauthClient().getRedirectUris(), List.of("https://example.com/callback"));
+    }
+
+    /**
+     * A partial object of a different concrete subtype than the application being updated (e.g. a
+     * {@code SamlApplication} partial against an OIDC app) would blend fields from incompatible
+     * application types if merged - reject it immediately instead of producing a confusing result.
+     */
+    @Test
+    public void mergeApplication_partialOfDifferentSubtype_throwsImmediately() {
+        OpenIdConnectApplication existing = fullyPopulatedExistingApp();
+        SamlApplication mismatchedPartial = new SamlApplication();
+
+        assertThrows(IllegalArgumentException.class, () ->
+            PartialApplicationUpdater.mergeApplication(apiClient.getObjectMapper(), existing, mismatchedPartial));
+    }
+}

--- a/api/src/test/java/com/okta/sdk/resource/client/ApiClientJacksonMixinTest.java
+++ b/api/src/test/java/com/okta/sdk/resource/client/ApiClientJacksonMixinTest.java
@@ -24,10 +24,12 @@ import com.okta.sdk.resource.model.AgentJsonSigningKeyResponse;
 import com.okta.sdk.resource.model.Application;
 import com.okta.sdk.resource.model.ApplicationVisibility;
 import com.okta.sdk.resource.model.ApplicationVisibilityHide;
+import com.okta.sdk.resource.model.KnowledgeConstraint;
 import com.okta.sdk.resource.model.ListJwk200ResponseInner;
 import com.okta.sdk.resource.model.ManagedConnection;
 import com.okta.sdk.resource.model.ManagedConnectionCreatable;
 import com.okta.sdk.resource.model.OpenIdConnectApplication;
+import com.okta.sdk.resource.model.PossessionConstraint;
 import com.okta.sdk.resource.model.OrgContactType;
 import com.okta.sdk.resource.model.OrgContactTypeObj;
 import com.okta.sdk.resource.model.PotentialConnection;
@@ -295,5 +297,37 @@ public class ApiClientJacksonMixinTest {
 
         assertEquals(connections.size(), 2);
         assertEquals(connections.get(1).getConnectionType(), PotentialConnection.ConnectionTypeEnum.STS_SERVICE_ACCOUNT);
+    }
+
+    /**
+     * OKTA-1232842: KnowledgeConstraint/PossessionConstraint's methods/types enums declare uppercase values
+     * (PASSWORD, PUSH, SECURITY_KEY, ...), matching the spec. But fromValue() did an exact-match equals(),
+     * so any lowercase variant of a value the API might send falls through to UNKNOWN_DEFAULT_OPEN_API
+     * instead of resolving to the real constant. useEnumCaseInsensitive makes matching case-insensitive.
+     */
+    @Test
+    public void deserializeKnowledgeConstraint_withLowercaseMethodsAndTypes_resolvesRealEnumConstants() throws Exception {
+        String json = "{\"methods\":[\"password\",\"push\"],\"types\":[\"security_key\",\"phone\"]}";
+
+        KnowledgeConstraint constraint = objectMapper.readValue(json, KnowledgeConstraint.class);
+
+        assertEquals(constraint.getMethods(),
+            List.of(KnowledgeConstraint.MethodsEnum.PASSWORD, KnowledgeConstraint.MethodsEnum.PUSH));
+        assertEquals(constraint.getTypes(),
+            List.of(KnowledgeConstraint.TypesEnum.SECURITY_KEY, KnowledgeConstraint.TypesEnum.PHONE));
+    }
+
+    /**
+     * Same fix, PossessionConstraint counterpart.
+     */
+    @Test
+    public void deserializePossessionConstraint_withLowercaseMethodsAndTypes_resolvesRealEnumConstants() throws Exception {
+        String json = "{\"methods\":[\"sms\"],\"types\":[\"app\",\"federated\"]}";
+
+        PossessionConstraint constraint = objectMapper.readValue(json, PossessionConstraint.class);
+
+        assertEquals(constraint.getMethods(), List.of(PossessionConstraint.MethodsEnum.SMS));
+        assertEquals(constraint.getTypes(),
+            List.of(PossessionConstraint.TypesEnum.APP, PossessionConstraint.TypesEnum.FEDERATED));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,16 @@
                         <skipTests>${skipImplTests}</skipTests>
                         <argLine>@{argLine} --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.text=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED</argLine>
                     </configuration>
+                    <dependencies>
+                        <!-- Every test class in every module uses TestNG, but api's junit-jupiter dependency
+                             makes Surefire auto-detect the JUnit Platform provider instead, which silently
+                             discovers zero tests. Declaring the TestNG provider explicitly forces its use. -->
+                        <dependency>
+                            <groupId>org.apache.maven.surefire</groupId>
+                            <artifactId>surefire-testng</artifactId>
+                            <version>3.5.3</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/src/swagger/api.yaml
+++ b/src/swagger/api.yaml
@@ -73314,8 +73314,10 @@ components:
           default: 1
         maxConsecutiveCharacters:
           type: integer
-          description: 'The maximum number of consecutive characters allowed in a password: `0` indicates no limit'
+          description: '<x-lifecycle-container><x-lifecycle class="ea"></x-lifecycle> <x-lifecycle class="oie"></x-lifecycle></x-lifecycle-container>The maximum number of consecutive characters allowed in a password: `0` indicates no limit'
           default: 0
+          x-okta-lifecycle:
+            lifecycle: EA
         oelStatement:
           type: string
           description: <x-lifecycle-container><x-lifecycle class="ea"></x-lifecycle> <x-lifecycle class="oie"></x-lifecycle></x-lifecycle-container>Use an [Expression Language](https://developer.okta.com/docs/reference/okta-expression-language-in-identity-engine/) expression to block a word from being used in a password. You can only block one word per expression. Use the `OR` operator to connect multiple expressions to block multiple words.


### PR DESCRIPTION
## Summary
- Add `PartialApplicationUpdater`, a helper that gives `Application` PUT requests real partial-update semantics: it fetches the existing application, merges in only the fields set on the caller's partial object, and replaces with the fully-populated result. Fixes partial updates failing when required sibling fields (e.g. `name`, `credentials` on `OpenIdConnectApplication`) are omitted.
- Make generated enum deserialization case-insensitive (`useEnumCaseInsensitive`). `KnowledgeConstraint`/`PossessionConstraint` enums are uppercase, but the API sends lowercase values, so `fromValue()` was falling through to `UNKNOWN_DEFAULT_OPEN_API`.
- Mark `maxConsecutiveCharacters` as EA in the spec, consistent with its sibling `oelStatement` field.
- Fix Surefire silently running zero tests in the `api` module: an unused `junit-jupiter` dependency caused it to pick the JUnit Platform provider over TestNG, which every test in this repo actually uses.

## Test plan
- [x] New unit tests for `PartialApplicationUpdater` covering partial updates that omit `name` and/or `credentials`
- [x] New unit tests for case-insensitive enum deserialization
- [x] Full suite passes: `api` and `impl` modules, all green
- [x] `PartialApplicationUpdater` additionally verified against a live test org

---
**AI Attribution:** `ai-agent-authored`