### PR TITLE
fix: bump httpclient5 to 5.6.4 to resolve CVE-2026-64607

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <snakeyaml.version>2.4</snakeyaml.version>
         <bouncycastle.version>1.84</bouncycastle.version>
         <jjwt.version>0.12.6</jjwt.version>
-        <org.apache.httpcomponents.client5.version>5.6.2</org.apache.httpcomponents.client5.version>
+        <org.apache.httpcomponents.client5.version>5.6.4</org.apache.httpcomponents.client5.version>
         <okta.sdk.previousVersion>24.0.1</okta.sdk.previousVersion>
         <okta.commons.version>2.0.1</okta.commons.version>
         <com.google.auto.service.version>1.1.1</com.google.auto.service.version>


### PR DESCRIPTION
## Summary
- Bumps `httpclient5` from 5.6.2 to 5.6.4 to resolve CVE-2026-64607 (CVSS 5.3), which affects the classic I/O model in versions 5.0.0 through 5.6.2. Fixed upstream in 5.6.3; 5.6.4 is the latest published patch in that line.
- Found via a local `dependency-check-maven:aggregate` scan.

## Test plan
- [ ] CI build passes